### PR TITLE
Populate blank count columns, move search features to top of pages 

### DIFF
--- a/app/es/es_query_builder.py
+++ b/app/es/es_query_builder.py
@@ -314,6 +314,22 @@ def list_episodes_by_season(show_key: str) -> Search:
     return s
 
 
+
+async def agg_seasons(show_key: str, location: str = None) -> Search:
+    print(f'begin agg_episodes for show_key={show_key} location={location}')
+
+    s = Search(index='transcripts')
+    s = s.extra(size=0)
+
+    s = s.filter('term', show_key=show_key)
+
+    s.aggs.bucket('by_season', 'terms', field='season', size=1000)
+
+    # TODO location
+
+    return s
+
+
 async def agg_episodes(show_key: str, season: str = None, location: str = None) -> Search:
     print(f'begin agg_episodes for show_key={show_key} season={season} location={location}')
 
@@ -326,6 +342,41 @@ async def agg_episodes(show_key: str, season: str = None, location: str = None) 
 
     # TODO location
 
+    return s
+
+
+async def agg_seasons_by_speaker(show_key: str, location: str = None) -> Search:
+    print(f'begin agg_episodes_by_speaker for show_key={show_key} location={location}')
+
+    s = Search(index='transcripts')
+    s = s.extra(size=0)
+
+    s = s.filter('term', show_key=show_key)
+
+    if location:
+        pass  # TODO copied from agg_episodes_by_speaker
+        # s.aggs.bucket(
+        #     'scenes', 'nested', path='scenes'
+        # ).bucket(
+        #     'location_match', 'filter', filter={"match": {"scenes.location": location}}
+        # ).bucket(
+        #     'scene_events', 'nested', path='scenes.scene_events'
+        # ).bucket(
+        #     'by_speaker', 'terms', field='scenes.scene_events.spoken_by.keyword', size=1000
+        # ).bucket(
+        #     'for_episode', 'reverse_nested'
+        # )
+    else:
+        s.aggs.bucket(
+            'scene_events', 'nested', path='scenes.scene_events'
+        ).bucket(
+            'by_speaker', 'terms', field='scenes.scene_events.spoken_by.keyword', size=1000
+        ).bucket(
+            'by_season', 'reverse_nested'
+        ).bucket(
+            'season', 'terms', field='season'
+        )
+    
     return s
 
 

--- a/app/es/es_query_builder.py
+++ b/app/es/es_query_builder.py
@@ -655,7 +655,7 @@ async def agg_dialog_word_counts(show_key: str, season: str = None, episode_key:
 
 
 async def keywords_by_episode(show_key: str, episode_key: str) -> dict:
-    print(f'begin calc_word_counts_by_episode for show_key={show_key} episode_key={episode_key}')
+    print(f'begin keywords_by_episode for show_key={show_key} episode_key={episode_key}')
 
     response = es_conn.termvectors(index='transcripts', id=f'{show_key}_{episode_key}', term_statistics='true', field_statistics='true',
                                    fields=['flattened_text'], filter={"max_num_terms": 1000, "min_term_freq": 1, "min_doc_freq": 1})
@@ -664,7 +664,7 @@ async def keywords_by_episode(show_key: str, episode_key: str) -> dict:
 
 
 async def keywords_by_corpus(show_key: str, season: str = None) -> dict:
-    print(f'begin calc_word_counts_by_episode for show_key={show_key} season={season}')
+    print(f'begin keywords_by_corpus for show_key={show_key} season={season}')
 
     keys = esr.search_doc_ids(ShowKey(show_key), season=season)
 

--- a/app/es/es_query_builder.py
+++ b/app/es/es_query_builder.py
@@ -380,6 +380,27 @@ async def agg_seasons_by_speaker(show_key: str, location: str = None) -> Search:
     return s
 
 
+async def agg_seasons_by_location(show_key: str) -> Search:
+    print(f'begin agg_episodes_by_speaker for show_key={show_key}')
+
+    s = Search(index='transcripts')
+    s = s.extra(size=0)
+
+    s = s.filter('term', show_key=show_key)
+
+    s.aggs.bucket(
+        'scenes', 'nested', path='scenes'
+    ).bucket(
+        'by_location', 'terms', field='scenes.location.keyword', size=1000
+    ).bucket(
+        'by_season', 'reverse_nested'
+    ).bucket(
+        'season', 'terms', field='season'
+    )
+    
+    return s
+
+
 async def agg_episodes_by_speaker(show_key: str, season: str = None, location: str = None, other_speaker: str = None) -> Search:
     print(f'begin agg_episodes_by_speaker for show_key={show_key} season={season} location={location} other_speaker={other_speaker}')
 
@@ -426,6 +447,27 @@ async def agg_episodes_by_speaker(show_key: str, season: str = None, location: s
         ).bucket(
             'for_episode', 'reverse_nested' # TODO differs from agg_scenes_by_speaker
         )
+    
+    return s
+
+
+async def agg_episodes_by_location(show_key: str, season: str = None) -> Search:
+    print(f'begin agg_episodes_by_speaker for show_key={show_key} season={season}')
+
+    s = Search(index='transcripts')
+    s = s.extra(size=0)
+
+    s = s.filter('term', show_key=show_key)
+    if season:
+        s = s.filter('term', season=season)
+
+    s.aggs.bucket(
+        'scenes', 'nested', path='scenes'
+    ).bucket(
+        'by_location', 'terms', field='scenes.location.keyword', size=1000
+    ).bucket(
+        'by_episode', 'reverse_nested'
+    )
     
     return s
 

--- a/app/es/es_read_router.py
+++ b/app/es/es_read_router.py
@@ -309,7 +309,7 @@ async def agg_dialog_word_counts(show_key: ShowKey, season: str = None, episode_
 
 @esr_app.get("/esr/composite_speaker_aggs/{show_key}", tags=['ES Reader'])
 async def composite_speaker_aggs(show_key: ShowKey, season: str = None, episode_key: str = None):
-    if not season:
+    if not season and not episode_key:
         speaker_season_counts = await agg_seasons_by_speaker(show_key)
     if not episode_key:
         speaker_episode_counts = await agg_episodes_by_speaker(show_key, season=season)
@@ -319,7 +319,7 @@ async def composite_speaker_aggs(show_key: ShowKey, season: str = None, episode_
 
     # TODO refactor this to generically handle dicts threading together
     speakers = {}
-    if not season:
+    if not season and not episode_key:
         for speaker, season_count in speaker_season_counts['seasons_by_speaker'].items():
             if speaker not in speakers:
                 speakers[speaker] = {}
@@ -359,7 +359,7 @@ async def composite_speaker_aggs(show_key: ShowKey, season: str = None, episode_
 
 @esr_app.get("/esr/composite_location_aggs/{show_key}", tags=['ES Reader'])
 async def composite_location_aggs(show_key: ShowKey, season: str = None, episode_key: str = None):
-    if not season:
+    if not season and not episode_key:
         location_season_counts = await agg_seasons_by_location(show_key)
     if not episode_key:
         location_episode_counts = await agg_episodes_by_location(show_key, season=season)
@@ -367,7 +367,7 @@ async def composite_location_aggs(show_key: ShowKey, season: str = None, episode
 
     # TODO refactor this to generically handle dicts threading together
     locations = {}
-    if not season:
+    if not season and not episode_key:
         for location, season_count in location_season_counts['seasons_by_location'].items():
             if location not in locations:
                 locations[location] = {}
@@ -384,8 +384,6 @@ async def composite_location_aggs(show_key: ShowKey, season: str = None, episode
             locations[location] = {}
             locations[location]['location'] = location
         locations[location]['scene_count'] = scene_count
-
-    # print(f'locations={locations}')
 
     # TODO shouldn't I be able to sort on a key for a dict within a dict
     location_dicts = locations.values()

--- a/app/es/es_read_router.py
+++ b/app/es/es_read_router.py
@@ -82,6 +82,8 @@ async def search_scene_events(show_key: ShowKey, season: str = None, episode_key
     '''
     Facet query of nested Scene and SceneEvent fields 
     '''
+    if not speaker and not dialog:
+        return {"error": "Unable to execute search_scene_events without at least one scene_event property set: speaker or dialog"}
     s = await esqb.search_scene_events(show_key.value, season=season, episode_key=episode_key, speaker=speaker, dialog=dialog)
     es_query = s.to_dict()
     matches, scene_count, scene_event_count = await esrt.return_scene_events(s, location=location)

--- a/app/es/es_response_transformer.py
+++ b/app/es/es_response_transformer.py
@@ -104,6 +104,8 @@ async def return_scene_events(s: Search, location: str = None) -> (list, int, in
         episode['score'] = hit._score
         episode['agg_score'] = hit._score
         episode['high_child_score'] = 0
+        episode['scene_event_count'] = 0
+        episode['word_count'] = 0
         orig_scenes = episode.scenes
 
         scene_offset_to_scene = {}
@@ -141,6 +143,10 @@ async def return_scene_events(s: Search, location: str = None) -> (list, int, in
             scene['scene_events'].append(scene_event._d_)
             scene['high_child_score'] = max(scene_event['score'], scene['high_child_score'])
             scene['agg_score'] += scene_event['score']
+            episode['scene_event_count'] += 1
+            # NOTE to be consistent, word_count would match the output of agg_dialog_word_counts (if that endpoint had a 'group by episode' option, which it doesn't)
+            if 'dialog' in scene_event._d_:
+                episode['word_count'] += len(scene_event._d_['dialog'].split(' '))
             scene_event_count += 1
 
         # NOTE follow-up to location-filter hack above, if all scenes have been filtered then skip episode 

--- a/app/es/es_response_transformer.py
+++ b/app/es/es_response_transformer.py
@@ -251,6 +251,39 @@ async def return_scene_events_multi_speaker(s: Search, speakers: str, location: 
     return results, scene_count, scene_event_count
 
 
+async def return_seasons_by_speaker(s: Search, agg_season_count: str, location: str = None) -> list:
+    print(f'begin return_seasons_by_speaker for location={location} s.to_dict()={s.to_dict()}')
+
+    s = s.execute()
+
+    results = {}
+    results['_ALL_'] = agg_season_count
+
+    if location:
+        pass  # TODO copied from return_episodes_by_speaker
+        # for item in s.aggregations.scenes.location_match.scene_events.by_speaker.buckets:
+        #     results[item.key] = item.for_episode.doc_count
+    else:
+        for item in s.aggregations.scene_events.by_speaker.buckets:
+            results[item.key] = len(item.by_season.season.buckets)
+
+    # reverse nesting throws off sorting, so sort results by value
+    sorted_results_list = sorted(results.items(), key=lambda x:x[1], reverse=True)
+    results = {}
+    for speaker, count in sorted_results_list:
+        results[speaker] = count
+
+    return results
+
+
+async def return_season_count(s: Search) -> int:
+    print(f'begin return_episode_count for s.to_dict()={s.to_dict()}')
+
+    s = s.execute()
+
+    return len(s.aggregations.by_season.buckets)
+
+
 async def return_episodes(s: Search) -> (list, int, int):
     print(f'begin return_episodes for s.to_dict()={s.to_dict()}')
 

--- a/app/es/es_response_transformer.py
+++ b/app/es/es_response_transformer.py
@@ -276,6 +276,26 @@ async def return_seasons_by_speaker(s: Search, agg_season_count: str, location: 
     return results
 
 
+async def return_seasons_by_location(s: Search, agg_season_count: str) -> list:
+    print(f'begin return_seasons_by_speaker s.to_dict()={s.to_dict()}')
+
+    s = s.execute()
+
+    results = {}
+    results['_ALL_'] = agg_season_count
+
+    for item in s.aggregations.scenes.by_location.buckets:
+        results[item.key] = len(item.by_season.season.buckets)
+
+    # reverse nesting throws off sorting, so sort results by value
+    sorted_results_list = sorted(results.items(), key=lambda x:x[1], reverse=True)
+    results = {}
+    for speaker, count in sorted_results_list:
+        results[speaker] = count
+
+    return results
+
+
 async def return_season_count(s: Search) -> int:
     print(f'begin return_episode_count for s.to_dict()={s.to_dict()}')
 
@@ -427,6 +447,26 @@ async def return_episodes_by_speaker(s: Search, agg_episode_count: str, location
     return results
 
 
+async def return_episodes_by_location(s: Search, agg_episode_count: str) -> list:
+    print(f'begin return_episodes_by_speaker s.to_dict()={s.to_dict()}')
+
+    s = s.execute()
+
+    results = {}
+    results['_ALL_'] = agg_episode_count
+
+    for item in s.aggregations.scenes.by_location.buckets:
+        results[item.key] = item.by_episode.doc_count
+
+    # reverse nesting throws off sorting, so sort results by value
+    sorted_results_list = sorted(results.items(), key=lambda x:x[1], reverse=True)
+    results = {}
+    for speaker, count in sorted_results_list:
+        results[speaker] = count
+
+    return results
+
+
 async def return_scene_count(s: Search) -> int:
     print(f'begin return_scene_count for s.to_dict()={s.to_dict()}')
 
@@ -441,15 +481,15 @@ async def return_scenes_by_location(s: Search, speaker: str = None) -> list:
     s = s.execute()
 
     results = {}
-    results['TOTAL'] = 0
+    results['_ALL_'] = 0
 
     if speaker:
         for item in s.aggregations.scene_events.speaker_match.scenes.by_location.buckets:
-            results['TOTAL'] += item.doc_count
+            results['_ALL_'] += item.doc_count
             results[item.key] = item.doc_count
     else:
         for item in s.aggregations.scenes.by_location.buckets:
-            results['TOTAL'] += item.doc_count
+            results['_ALL_'] += item.doc_count
             results[item.key] = item.doc_count
 
     return results

--- a/app/templates/character.html
+++ b/app/templates/character.html
@@ -10,219 +10,237 @@
         <h5>{{ tdata['episode_count'] }} episodes, {{ tdata['scene_count'] }} scenes, {{ tdata['scene_event_count'] }} lines, {{ tdata['word_count'] }} words</h5>
 		<p>&nbsp;</p>
 
-        <!-- begin statistics frames -->
+
         <div class="row">
-            <div class="col-5">
-                <h3>{{ tdata['episode_count'] }} episodes with {{ tdata['speaker'] }}</h3></h3>
-                <div class="overflow-scroll" style="max-height: 600px;">
-					<table class="table table-hover table-striped table-fit">
-						<thead>
-							<tr class="table-success">
-								<th scope="col">Title</th>
-								<th scope="col">Season</th>
-								<th scope="col">Episode</th>
-								<th scope="col">Air date</th>
-								<th scope="col">Score</th>
-							</tr>
-						</thead>
-						<tbody>
-							{% for episode in tdata['episodes'] %}
-							<tr class="table-light">
-								<th scope="row"><a href="/web/episode/{{ episode['show_key'] }}/{{ episode['episode_key'] }}">{{ episode['title'] }}</a></th>
-								<td>{{ episode['season'] }}</td>
-								<td>{{ episode['sequence_in_season'] }}</td>
-								<td>{{ episode['air_date']|truncate(10,true,'') }}</td>
-								<td>{{ '%0.2f'|format(episode['agg_score']|float) }}</td>
-							</tr>
-							{% endfor %}
-						</tbody>
-					</table>
-				</div>
-            </div>
-			<div class="col-3">
-                <h3>Where is {{ tdata['speaker'] }}?</h3>
-                <div class="overflow-scroll" style="max-height: 600px;">
-                    <table class="table table-hover table-striped table-fit">
-                        <thead>
-                            <tr class="table-primary">
-                                <th scope="col">Location</th>
-                                <th scope="col">Scenes</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for location, count in tdata['location_counts'].items() %}
-                            <tr class="table-secondary">
-                                <th scope="row">{{ location }}</th>
-                                <td><a href="
-                                    {% if location == 'TOTAL' %}
-                                        /web/episode_search/{{ tdata['show_key'] }}?speaker={{ tdata['speaker'] }}&search_type=advanced
-                                    {% else %}
-                                        /web/episode_search/{{ tdata['show_key'] }}?speaker={{ tdata['speaker'] }}&location={{ location }}&search_type=advanced
+            <div class="col-6">
+                <!-- begin character-centric search form -->
+                <h3>{{ tdata['speaker'] }}-affiliated search</h3>
+                <br/>
+                <form action="/web/character/{{ tdata['show_key'] }}/{{ tdata['speaker'] }}" method="GET">
+                    <!-- https://getbootstrap.com/docs/5.0/components/navs-tabs/#javascript-behavior -->
+                    <nav>
+                        <div class="nav nav-tabs" id="nav-tab" role="tablist">
+                            <button class="nav-link{% if tdata['search_type']=='' or tdata['search_type']=='advanced' %} active{% endif %}" id="nav-advanced-tab" 
+                                    data-bs-toggle="tab" data-bs-target="#nav-advanced" type="button" role="tab" aria-controls="nav-advanced" aria-selected="false">
+                                Dialog search
+                            </button>
+                            <button class="nav-link{% if tdata['search_type']=='advanced_multi_speaker' %} active{% endif %}" id="nav-advanced-multi-character-tab" 
+                                    data-bs-toggle="tab" data-bs-target="#nav-advanced-multi-character" type="button" role="tab" aria-controls="nav-advanced-multi-character" aria-selected="false">
+                                Multi-character search
+                            </button>
+                        </div>
+                    </nav>
+                    <br/>
+                    <div class="tab-content" id="nav-tabContent">
+                        <div class="tab-pane fade{% if tdata['search_type']=='' or tdata['search_type']=='advanced' %} show active{% endif %}" id="nav-advanced" role="tabpanel" aria-labelledby="nav-advanced-tab">
+                            <div class="col-10">
+                                <div class="row input-group">
+                                    <div class="col-3">
+                                        <label class="col-form-label">By dialogue:</label>
+                                    </div>
+                                    <div class="col-6"> 
+                                        <input type="text" class="form-control" name="dialog" value="{{ tdata['dialog'] }}" id="dialogInput">
+                                    </div>
+                                </div>                        
+                                <div class="row input-group">
+                                    <div class="col-3">
+                                        <label class="col-form-label">By location:</label>
+                                    </div>
+                                    <div class="col-6"> 
+                                        <input type="text" class="form-control" name="location" value="{{ tdata['location'] }}" id="locationInput">
+                                    </div>
+                                </div>
+                                <br/>
+                                <div class="row input-group">
+                                    <div class="col-9">
+                                        <button type="submit" class="btn btn-primary" name="search_type" value="advanced">Search</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="tab-pane fade{% if tdata['search_type']=='advanced_multi_speaker' %} show active{% endif %}" id="nav-advanced-multi-character" role="tabpanel" aria-labelledby="nav-advanced-multi-character-tab">
+                            <div class="col-10">
+                                <div class="row input-group">
+                                    <div class="col-4">
+                                        <label class="col-form-label">By other character(s):</label>
+                                    </div>
+                                    <div class="col-6"> 
+                                        <input type="text" class="form-control" name="speakers" value="{{ tdata['speakers'] }}" id="speakersInput">
+                                    </div>
+                                </div>                              
+                                <div class="row input-group">
+                                    <div class="col-4">
+                                        <label class="col-form-label">By location:</label>
+                                    </div>
+                                    <div class="col-6"> 
+                                        <input type="text" class="form-control" name="locationAMS" value="{{ tdata['locationAMS'] }}" id="locationAMSInput">
+                                    </div>
+                                </div>
+                                <br/>
+                                <div class="row input-group">
+                                    <div class="col-6">
+                                        <button type="submit" class="btn btn-primary" name="search_type" value="advanced_multi_speaker">Search</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <br/>
+                </form>
+                <br/>
+                <!-- end in-episode search form -->
+
+                {% if tdata['search_type'] != '' %}
+                    <!-- begin search result count summary -->
+                    <h3><strong>{{ tdata['episode_match_count'] }}</strong> episodes / 
+                        <strong>{{ tdata['scene_match_count'] }}</strong> scenes / 
+                        <strong>{{ tdata['scene_event_match_count'] }}</strong> lines matching <strong class="gold">"{{ tdata['speaker'] }}"</strong>
+                        {% if tdata['search_type'] == 'advanced' %}
+                            {% if tdata['dialog'] %} + dialogue: <strong class="gold">"{{ tdata['dialog'] }}"</strong>{% endif %}
+                            {% if tdata['location'] %} + location: <strong class="gold">"{{ tdata['location'] }}"</strong>{% endif %}
+                        {% endif %}
+                        {% if tdata['search_type'] == 'advanced_multi_speaker' %}
+                            {% if tdata['speakers'] %} + other characters: <strong class="gold">"{{ tdata['speakers'] }}"</strong>{% endif %}
+                            {% if tdata['locationAMS'] %} + location: <strong class="gold">"{{ tdata['locationAMS'] }}"</strong>{% endif %}
+                        {% endif %}
+                        {% if tdata['season'] %}, Season <strong>{{ tdata['season'] }}</strong>{% endif %}
+                    </h3>
+                    <p>&nbsp;</p>
+                    <!-- end search result count summary -->
+
+                    <!-- begin display search results -->
+                    {% for episode in tdata['episode_matches'] %}
+                    <div class="card text-white bg-success mb-3 w-75">
+                        <div class="card-header">Season {{ episode['season'] }}, Episode {{ episode['sequence_in_season'] }} ({{ episode['air_date']|truncate(10,true,'') }})</div>
+                        <div class="card-body">
+                            <h5 class="card-title">
+                                <button type="button" class="btn btn-primary">{{ '%0.2f'|format(episode['agg_score']|float) }}</button>&nbsp;&nbsp;
+                                <a class="alert-link" href="/web/episode/{{ episode['show_key'] }}/{{ episode['episode_key'] }}">{{ episode['title']|safe }}</a> 
+                            </h5>
+                            <div class="overflow-scroll" style="max-height: 300px;">
+                            {% for scene in episode['scenes'] %}
+                                <hr>
+                                <p>[scene {{ scene['sequence'] }}] <strong>{{ scene['location']|safe }}</strong></p>
+                                <p><small>
+                                {% for scene_event in scene['scene_events'] %}
+                                    [line {{ scene_event['sequence'] }}] 
+                                    {% if scene_event['context_info'] %}
+                                        [{{ scene_event['context_info']|safe }}] 
                                     {% endif %}
-                                        " class="alert-link" >{{ count }}</a>
-                                </td>
-                            </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
+                                    {% if scene_event['spoken_by'] %}
+                                        <strong>{{ scene_event['spoken_by']|safe }}</strong>: {{ scene_event['dialog']|safe }}
+                                    {% endif %}
+                                    <br/>
+                                {% endfor %}
+                                </small></p>
+                                {% endfor %}
+                            </div>
+                        </div>
+                    </div>
+                    {% endfor %}
+                    <!-- end display search results -->
+                {% endif %}
             </div>
-            <div class="col-3">
-                <h3>Who is {{ tdata['speaker'] }} with?</h3>
-                <div class="overflow-scroll" style="max-height: 600px;">
-                    <table class="table table-hover table-striped table-fit">
-                        <thead>
-                            <tr class="table-success">
-                                <th scope="col">Character</th>
-                                <th scope="col">Episodes</th>
-                                <th scope="col">Scenes</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for other_speaker_aggs in tdata['other_speaker_agg_composite'] %}
-                            <tr class="table-secondary">
-                                <th scope="row"><a class="alert-link" href="/web/character/{{ tdata['show_key'] }}/{{ other_speaker_aggs['other_speaker'] }}">{{ other_speaker_aggs['other_speaker'] }}</a></th>
-                                <td><a href="/web/episode_search/{{ tdata['show_key'] }}?speakers={{ tdata['speaker'] }},{{ other_speaker_aggs['other_speaker'] }}&search_type=advanced_multi_speaker" 
-                                        class="alert-link" >{{ other_speaker_aggs['episode_count'] }}</a></td>
-                                <td>{{ other_speaker_aggs['scene_count'] }}</td>
-                            </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
+
+            <!-- begin statistics frames -->
+            <div class="col-6">
+                <div class="row">
+                    <div class="col-12">
+                        <h3>{{ tdata['episode_count'] }} episodes with {{ tdata['speaker'] }}</h3></h3>
+                        <div class="overflow-scroll" style="max-height: 600px;">
+                            <table class="table table-hover table-striped table-fit">
+                                <thead>
+                                    <tr class="table-success">
+                                        <th scope="col">Title</th>
+                                        <th scope="col">Season</th>
+                                        <th scope="col">Episode</th>
+                                        <th scope="col">Air date</th>
+                                        <th scope="col">Scenes</th>
+                                        <th scope="col">Lines</th>
+                                        <th scope="col">Words</th>
+                                        <th scope="col">Score</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for episode in tdata['episodes'] %}
+                                    <tr class="table-light">
+                                        <th scope="row"><a href="/web/episode/{{ episode['show_key'] }}/{{ episode['episode_key'] }}">{{ episode['title'] }}</a></th>
+                                        <td>{{ episode['season'] }}</td>
+                                        <td>{{ episode['sequence_in_season'] }}</td>
+                                        <td>{{ episode['air_date']|truncate(10,true,'') }}</td>
+                                        <td>...</td>
+                                        <td>...</td>
+                                        <td>...</td>
+                                        <!-- <td>{{ episode['scenes'] }}</td>
+                                        <td>{{ episode['lines'] }}</td>
+                                        <td>{{ episode['words'] }}</td> -->
+                                        <td>{{ '%0.2f'|format(episode['agg_score']|float) }}</td>
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+                <p>&nbsp;</p>
+                <div class="row">
+                    <div class="col-6">
+                        <h3>Where is {{ tdata['speaker'] }}?</h3>
+                        <div class="overflow-scroll" style="max-height: 600px;">
+                            <table class="table table-hover table-striped table-fit">
+                                <thead>
+                                    <tr class="table-primary">
+                                        <th scope="col">Location</th>
+                                        <th scope="col">Scenes</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for location, count in tdata['location_counts'].items() %}
+                                    <tr class="table-secondary">
+                                        {% if location == '_ALL_' %}
+                                        <th scope="row">[ALL]</th>
+                                        <td><a href="/web/episode_search/{{ tdata['show_key'] }}?speaker={{ tdata['speaker'] }}&search_type=advanced" 
+                                            class="alert-link" >{{ count }}</a></td>
+                                        {% else %}
+                                        <th scope="row">{{ location }}</th>
+                                        <td><a href="/web/episode_search/{{ tdata['show_key'] }}?speaker={{ tdata['speaker'] }}&location={{ location }}&search_type=advanced" 
+                                            class="alert-link" >{{ count }}</a></td>
+                                        </td>
+                                        {% endif %}
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="col-6">
+                        <h3>Who is {{ tdata['speaker'] }} with?</h3>
+                        <div class="overflow-scroll" style="max-height: 600px;">
+                            <table class="table table-hover table-striped table-fit">
+                                <thead>
+                                    <tr class="table-success">
+                                        <th scope="col">Character</th>
+                                        <th scope="col">Episodes</th>
+                                        <th scope="col">Scenes</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for other_speaker_aggs in tdata['other_speaker_agg_composite'] %}
+                                    <tr class="table-secondary">
+                                        <th scope="row"><a class="alert-link" href="/web/character/{{ tdata['show_key'] }}/{{ other_speaker_aggs['other_speaker'] }}">{{ other_speaker_aggs['other_speaker'] }}</a></th>
+                                        <td><a href="/web/episode_search/{{ tdata['show_key'] }}?speakers={{ tdata['speaker'] }},{{ other_speaker_aggs['other_speaker'] }}&search_type=advanced_multi_speaker" 
+                                                class="alert-link" >{{ other_speaker_aggs['episode_count'] }}</a></td>
+                                        <td>{{ other_speaker_aggs['scene_count'] }}</td>
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
-        <p>&nbsp;</p>
         <!-- end statistics frames -->
-
-        <!-- begin character-centric search form -->
-		<h3>{{ tdata['speaker'] }}-affiliated search</h3>
-		<br/>
-		<form action="/web/character/{{ tdata['show_key'] }}/{{ tdata['speaker'] }}" method="GET">
-            <!-- https://getbootstrap.com/docs/5.0/components/navs-tabs/#javascript-behavior -->
-            <nav>
-                <div class="nav nav-tabs" id="nav-tab" role="tablist">
-                    <button class="nav-link{% if tdata['search_type']=='' or tdata['search_type']=='advanced' %} active{% endif %}" id="nav-advanced-tab" 
-							data-bs-toggle="tab" data-bs-target="#nav-advanced" type="button" role="tab" aria-controls="nav-advanced" aria-selected="false">
-                        Dialog search
-                    </button>
-                    <button class="nav-link{% if tdata['search_type']=='advanced_multi_speaker' %} active{% endif %}" id="nav-advanced-multi-character-tab" 
-							data-bs-toggle="tab" data-bs-target="#nav-advanced-multi-character" type="button" role="tab" aria-controls="nav-advanced-multi-character" aria-selected="false">
-                        Multi-character search
-                    </button>
-                </div>
-            </nav>
-            <br/>
-            <div class="tab-content" id="nav-tabContent">
-                <div class="tab-pane fade{% if tdata['search_type']=='' or tdata['search_type']=='advanced' %} show active{% endif %}" id="nav-advanced" role="tabpanel" aria-labelledby="nav-advanced-tab">
-                    <div class="col-8">
-                        <div class="row input-group">
-                            <div class="col-2">
-                                <label class="col-form-label">By dialogue:</label>
-                            </div>
-                            <div class="col-6"> 
-                                <input type="text" class="form-control" name="dialog" value="{{ tdata['dialog'] }}" id="dialogInput">
-                            </div>
-                        </div>                        
-                        <div class="row input-group">
-                            <div class="col-2">
-                                <label class="col-form-label">By location:</label>
-                            </div>
-                            <div class="col-6"> 
-                                <input type="text" class="form-control" name="location" value="{{ tdata['location'] }}" id="locationInput">
-                            </div>
-                        </div>
-                        <br/>
-                        <div class="row input-group">
-                            <div class="col-8">
-                                <button type="submit" class="btn btn-primary" name="search_type" value="advanced">Search</button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="tab-pane fade{% if tdata['search_type']=='advanced_multi_speaker' %} show active{% endif %}" id="nav-advanced-multi-character" role="tabpanel" aria-labelledby="nav-advanced-multi-character-tab">
-                    <div class="col-8">
-                        <div class="row input-group">
-                            <div class="col-2">
-                                <label class="col-form-label">By other character(s):</label>
-                            </div>
-                            <div class="col-6"> 
-                                <input type="text" class="form-control" name="speakers" value="{{ tdata['speakers'] }}" id="speakersInput">
-                            </div>
-                        </div>                              
-                        <div class="row input-group">
-                            <div class="col-2">
-                                <label class="col-form-label">By location:</label>
-                            </div>
-                            <div class="col-6"> 
-                                <input type="text" class="form-control" name="locationAMS" value="{{ tdata['locationAMS'] }}" id="locationAMSInput">
-                            </div>
-                        </div>
-                        <br/>
-                        <div class="row input-group">
-                            <div class="col-8">
-                                <button type="submit" class="btn btn-primary" name="search_type" value="advanced_multi_speaker">Search</button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <br/>
-        </form>
-        <br/>
-		<!-- end in-episode search form -->
-
-        {% if tdata['search_type'] != '' %}
-            <!-- begin search result count summary -->
-            <h3><strong>{{ tdata['episode_match_count'] }}</strong> episodes / 
-                <strong>{{ tdata['scene_match_count'] }}</strong> scenes / 
-                <strong>{{ tdata['scene_event_match_count'] }}</strong> lines matching <strong class="gold">"{{ tdata['speaker'] }}"</strong>
-                {% if tdata['search_type'] == 'advanced' %}
-                    {% if tdata['dialog'] %} + dialogue: <strong class="gold">"{{ tdata['dialog'] }}"</strong>{% endif %}
-                    {% if tdata['location'] %} + location: <strong class="gold">"{{ tdata['location'] }}"</strong>{% endif %}
-                {% endif %}
-                {% if tdata['search_type'] == 'advanced_multi_speaker' %}
-                    {% if tdata['speakers'] %} + other characters: <strong class="gold">"{{ tdata['speakers'] }}"</strong>{% endif %}
-                    {% if tdata['locationAMS'] %} + location: <strong class="gold">"{{ tdata['locationAMS'] }}"</strong>{% endif %}
-                {% endif %}
-                {% if tdata['season'] %}, Season <strong>{{ tdata['season'] }}</strong>{% endif %}
-            </h3>
-            <p>&nbsp;</p>
-            <!-- end search result count summary -->
-
-            <!-- begin display search results -->
-            {% for episode in tdata['episode_matches'] %}
-            <div class="card text-white bg-success mb-3 w-75">
-                <div class="card-header">Season {{ episode['season'] }}, Episode {{ episode['sequence_in_season'] }} ({{ episode['air_date']|truncate(10,true,'') }})</div>
-                <div class="card-body">
-                    <h5 class="card-title">
-                        <button type="button" class="btn btn-primary">{{ '%0.2f'|format(episode['agg_score']|float) }}</button>&nbsp;&nbsp;
-                        <a class="alert-link" href="/web/episode/{{ episode['show_key'] }}/{{ episode['episode_key'] }}">{{ episode['title']|safe }}</a> 
-                    </h5>
-                    <div class="overflow-scroll" style="max-height: 300px;">
-                    {% for scene in episode['scenes'] %}
-                        <hr>
-                        <p>[scene {{ scene['sequence'] }}] <strong>{{ scene['location']|safe }}</strong></p>
-                        <p><small>
-                        {% for scene_event in scene['scene_events'] %}
-                            [line {{ scene_event['sequence'] }}] 
-                            {% if scene_event['context_info'] %}
-                                [{{ scene_event['context_info']|safe }}] 
-                            {% endif %}
-                            {% if scene_event['spoken_by'] %}
-                                <strong>{{ scene_event['spoken_by']|safe }}</strong>: {{ scene_event['dialog']|safe }}
-                            {% endif %}
-                            <br/>
-                        {% endfor %}
-                        </small></p>
-                        {% endfor %}
-                    </div>
-                </div>
-            </div>
-            {% endfor %}
-            <!-- end display search results -->
-        {% endif %}
-        
 		
     </div>
 {% endblock %} 

--- a/app/templates/character.html
+++ b/app/templates/character.html
@@ -168,12 +168,9 @@
                                         <td>{{ episode['season'] }}</td>
                                         <td>{{ episode['sequence_in_season'] }}</td>
                                         <td>{{ episode['air_date']|truncate(10,true,'') }}</td>
-                                        <td>...</td>
-                                        <td>...</td>
-                                        <td>...</td>
-                                        <!-- <td>{{ episode['scenes'] }}</td>
-                                        <td>{{ episode['lines'] }}</td>
-                                        <td>{{ episode['words'] }}</td> -->
+                                        <td>{{ episode['scene_count'] }}</td>
+                                        <td>{{ episode['scene_event_count'] }}</td>
+                                        <td>{{ episode['word_count'] }}</td>
                                         <td>{{ '%0.2f'|format(episode['agg_score']|float) }}</td>
                                     </tr>
                                     {% endfor %}

--- a/app/templates/character.html
+++ b/app/templates/character.html
@@ -31,7 +31,7 @@
 								<th scope="row"><a href="/web/episode/{{ episode['show_key'] }}/{{ episode['episode_key'] }}">{{ episode['title'] }}</a></th>
 								<td>{{ episode['season'] }}</td>
 								<td>{{ episode['sequence_in_season'] }}</td>
-								<td>{{ episode['air_date'] }}</td>
+								<td>{{ episode['air_date']|truncate(10,true,'') }}</td>
 								<td>{{ '%0.2f'|format(episode['agg_score']|float) }}</td>
 							</tr>
 							{% endfor %}
@@ -193,7 +193,7 @@
             <!-- begin display search results -->
             {% for episode in tdata['episode_matches'] %}
             <div class="card text-white bg-success mb-3 w-75">
-                <div class="card-header">Season {{ episode['season'] }}, Episode {{ episode['sequence_in_season'] }} ({{ episode['air_date'] }})</div>
+                <div class="card-header">Season {{ episode['season'] }}, Episode {{ episode['sequence_in_season'] }} ({{ episode['air_date']|truncate(10,true,'') }})</div>
                 <div class="card-body">
                     <h5 class="card-title">
                         <button type="button" class="btn btn-primary">{{ '%0.2f'|format(episode['agg_score']|float) }}</button>&nbsp;&nbsp;

--- a/app/templates/characterListing.html
+++ b/app/templates/characterListing.html
@@ -89,7 +89,7 @@
                             <a class="alert-link" href="/web/character/{{ tdata['show_key'] }}/{{ speaker['speaker'] }}">{{ speaker['speaker'] }}</a>
                         {% endif %}
                     </th>
-                    <td>...</td>
+                    <td>{{ speaker['season_count'] }}</td>
                     <td>
                         {% if speaker['speaker'] == '_ALL_' %}
                             {{ speaker['episode_count'] }}

--- a/app/templates/episode.html
+++ b/app/templates/episode.html
@@ -212,13 +212,15 @@
 								<tbody>
 									{% for location, count in tdata['locations_by_scene'].items() %}
 									<tr class="table-secondary">
+										{% if location == '_ALL_' %}
+										<th scope="row">[ALL]</th>
+										<td><strong>{{ count }}</strong></td>
+										{% else %}
 										<th scope="row">{{ location }}</th>
 										<td>
-										{% if location == 'TOTAL' %}
-											<strong>{{ count }}</strong>
-										{% else %}
 											<a href="/web/episode/{{ tdata['show_key'] }}/{{ tdata['episode_key'] }}/?location={{ location }}&search_type=advanced" 
 												class="alert-link" >{{ count }}</a>
+										</td>
 										{% endif %}
 										</td>
 									</tr>

--- a/app/templates/episode.html
+++ b/app/templates/episode.html
@@ -7,310 +7,359 @@
 {% block content %} 
 	<div class="margin">
 		<h3>Season {{ tdata['episode']['season'] }}, Episode {{ tdata['episode']['sequence_in_season'] }}: 
-			<strong>"{{ tdata['episode']['title'] }}"</strong> <small>({{ tdata['episode']['air_date'] }})</small>
+			<strong>"{{ tdata['episode']['title'] }}"</strong> <small>({{ tdata['episode']['air_date']|truncate(10,true,'') }})</small>
 		</h3>
 		<p>&lt;&lt;&nbsp; Previous episode &nbsp;|&nbsp; Next episode &nbsp;&gt;&gt;</p>
 		<p>&nbsp;</p>
 
-		<!-- begin statistics frames -->
 		<div class="row">
-			<div class="col-2">
-				<h3>Locations</h3>
-				<div class="overflow-scroll" style="max-height: 600px;">
-					<table class="table table-hover table-striped table-fit">
-						<thead>
-							<tr class="table-primary">
-								<th scope="col">Location</th>
-								<th scope="col">Scenes</th>
-							</tr>
-						</thead>
-						<tbody>
-							{% for location, count in tdata['locations_by_scene'].items() %}
-							<tr class="table-secondary">
-								<th scope="row">{{ location }}</th>
-								<td>
-								{% if location == 'TOTAL' %}
-									<strong>{{ count }}</strong>
-								{% else %}
-									<a href="/web/episode/{{ tdata['show_key'] }}/{{ tdata['episode_key'] }}/?location={{ location }}&search_type=advanced" 
-										class="alert-link" >{{ count }}</a>
+			<!-- begin in-episode search form -->
+			<div class="col-6">
+				<h3>In-episode search</h3>
+				<br/>
+				<form action="/web/episode/{{ tdata['show_key'] }}/{{ tdata['episode_key'] }}" method="GET">
+					<!-- https://getbootstrap.com/docs/5.0/components/navs-tabs/#javascript-behavior -->
+					<nav>
+						<div class="nav nav-tabs" id="nav-tab" role="tablist">
+							<button class="nav-link{% if tdata['search_type']=='' or tdata['search_type']=='general' %} active{% endif %}" id="nav-general-tab" 
+									data-bs-toggle="tab" data-bs-target="#nav-general" type="button" role="tab" aria-controls="nav-general" aria-selected="true">
+								Keyword search
+							</button>
+							<button class="nav-link{% if tdata['search_type']=='advanced' %} active{% endif %}" id="nav-advanced-tab" 
+									data-bs-toggle="tab" data-bs-target="#nav-advanced" type="button" role="tab" aria-controls="nav-advanced" aria-selected="false">
+								Filter search
+							</button>
+							<button class="nav-link{% if tdata['search_type']=='advanced_multi_speaker' %} active{% endif %}" id="nav-advanced-multi-character-tab" 
+									data-bs-toggle="tab" data-bs-target="#nav-advanced-multi-character" type="button" role="tab" aria-controls="nav-advanced-multi-character" aria-selected="false">
+								Multi-character search
+							</button>
+							<button class="nav-link" id="nav-reset-tab" href="/web/episode/{{ tdata['show_key'] }}/{{ tdata['episode_key'] }}">
+								Clear search/reload transcript
+							</button>
+						</div>
+					</nav>
+					<br/>
+					<div class="tab-content" id="nav-tabContent">
+						<div class="tab-pane fade{% if tdata['search_type']=='' or tdata['search_type']=='general' %} show active{% endif %}" id="nav-general" role="tabpanel" aria-labelledby="nav-general-tab">
+							<div class="col-9">
+								<div class="row input-group">
+									<div class="col-5">
+										<label class="col-form-label">Find lines containing:</label>
+									</div>
+									<div class="col-5"> 
+										<input type="text" class="form-control" name="qt" value="{{ tdata['qt'] }}" id="qtInput">
+									</div>
+									<div class="col-2">
+										<button type="submit" class="btn btn-primary" name="search_type" value="general">Search</button>
+									</div>
+								</div>
+							</div>
+						</div>
+						<div class="tab-pane fade{% if tdata['search_type']=='advanced' %} show active{% endif %}" id="nav-advanced" role="tabpanel" aria-labelledby="nav-advanced-tab">
+							<div class="col-8">
+								<div class="row input-group">
+									<div class="col-4">
+										<label class="col-form-label">By character:</label>
+									</div>
+									<div class="col-6"> 
+										<input type="text" class="form-control" name="speaker" value="{{ tdata['speaker'] }}" id="speakerInput">
+									</div>
+								</div>
+								<div class="row input-group">
+									<div class="col-4">
+										<label class="col-form-label">By dialogue:</label>
+									</div>
+									<div class="col-6"> 
+										<input type="text" class="form-control" name="dialog" value="{{ tdata['dialog'] }}" id="dialogInput">
+									</div>
+								</div>                        
+								<div class="row input-group">
+									<div class="col-4">
+										<label class="col-form-label">By location:</label>
+									</div>
+									<div class="col-6"> 
+										<input type="text" class="form-control" name="location" value="{{ tdata['location'] }}" id="locationInput">
+									</div>
+								</div>
+								<br/>
+								<div class="row input-group">
+									<div class="col-8">
+										<button type="submit" class="btn btn-primary" name="search_type" value="advanced">Search</button>
+									</div>
+								</div>
+							</div>
+						</div>
+						<div class="tab-pane fade{% if tdata['search_type']=='advanced_multi_speaker' %} show active{% endif %}" id="nav-advanced-multi-character" role="tabpanel" aria-labelledby="nav-advanced-multi-character-tab">
+							<div class="col-8">
+								<div class="row input-group">
+									<div class="col-4">
+										<label class="col-form-label">By characters:</label>
+									</div>
+									<div class="col-6"> 
+										<input type="text" class="form-control" name="speakers" value="{{ tdata['speakers'] }}" id="speakersInput">
+									</div>
+								</div>                              
+								<div class="row input-group">
+									<div class="col-4">
+										<label class="col-form-label">By location:</label>
+									</div>
+									<div class="col-6"> 
+										<input type="text" class="form-control" name="locationAMS" value="{{ tdata['locationAMS'] }}" id="locationAMSInput">
+									</div>
+								</div>
+								<br/>
+								<div class="row input-group">
+									<div class="col-8">
+										<button type="submit" class="btn btn-primary" name="search_type" value="advanced_multi_speaker">Search</button>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+				</form>
+				<br/>
+				<!-- end in-episode search form -->
+
+				<!-- begin search result count summary -->
+				{% if tdata['search_type'] != '' %}
+					<h3><strong>{{ tdata['scene_match_count'] }}</strong> scenes / 
+						<strong>{{ tdata['scene_event_match_count'] }}</strong> lines matching 
+					{% if tdata['search_type'] == 'general' %}
+						query: <strong class="gold">"{{ tdata['qt'] }}"</strong>
+					{% endif %}
+					{% if tdata['search_type'] == 'advanced' %}
+						{% if tdata['speaker'] %} character: <strong class="gold">"{{ tdata['speaker'] }}"</strong>{% endif %}
+						{% if tdata['dialog'] %} dialogue: <strong class="gold">"{{ tdata['dialog'] }}"</strong>{% endif %}
+						{% if tdata['location'] %} location: <strong class="gold">"{{ tdata['location'] }}"</strong>{% endif %}
+						{% if tdata['season'] %}, Season <strong>{{ tdata['season'] }}</strong>{% endif %}
+					{% endif %}
+					{% if tdata['search_type'] == 'advanced_multi_speaker' %}
+						{% if tdata['speakers'] %} characters: <strong class="gold">"{{ tdata['speakers'] }}"</strong>{% endif %}
+						{% if tdata['locationAMS'] %} location: <strong class="gold">"{{ tdata['locationAMS'] }}"</strong>{% endif %}
+					{% endif %}
+					{% if tdata['season'] %}, Season <strong>{{ tdata['season'] }}</strong>{% endif %}
+					</h3>
+				{% endif %}
+				<p>&nbsp;</p>
+				<!-- end search result count summary -->
+
+				<!-- begin subset of transcript matching search query -->
+				{% if tdata['search_type'] != '' %}
+					{% if tdata['episode_match'] and tdata['episode_match']['scenes'] %}
+					<div class="card text-white bg-success mb-3 w-90">
+						<div class="card-body">
+						{% for scene in tdata['episode_match']['scenes'] %}
+							<hr>
+							<p>[scene {{ scene['sequence'] }}] <strong>{{ scene['location']|safe }}</strong></p>
+							<p><small>
+							{% for scene_event in scene['scene_events'] %}
+								[line {{ scene_event['sequence'] }}] 
+								{% if scene_event['context_info'] %}
+									[{{ scene_event['context_info']|safe }}] 
 								{% endif %}
-								</td>
-							</tr>
+								{% if scene_event['spoken_by'] %}
+									<strong>{{ scene_event['spoken_by']|safe }}</strong>: {{ scene_event['dialog']|safe }}
+								{% endif %}
+								<br/>
 							{% endfor %}
-						</tbody>
-					</table>
-				</div>
-			</div>
-			<div class="col-3">
-				<h3>Characters</h3>
-				<div class="overflow-scroll" style="max-height: 600px;">
-					<table class="table table-hover table-striped table-fit">
-						<thead>
-							<tr class="table-success">
-								<th scope="col">Speaker</th>
-								<th scope="col">Scenes</th>
-								<th scope="col">Lines</th>
-								<th scope="col">Words</th>
-							</tr>
-						</thead>
-						<tbody>
-						{% for speaker in tdata['speaker_counts'] %}
-							<tr class="table-secondary">
-							{% if speaker['speaker'] == '_ALL_' %}
-								<th scope="row">[ALL]</th>
-								<td><strong>{{ speaker['scene_count'] }}</strong></td>
-								<td><strong>{{ speaker['line_count'] }}</strong></td>
-								<td><strong>{{ speaker['word_count'] }}</strong></td>
-							{% else %}
-								<th scope="row">
-									<a href="/web/character/{{ tdata['show_key'] }}/{{ speaker['speaker'] }}" 
-										class="alert-link" >{{ speaker['speaker'] }}</a></th>
-								<td><a href="/web/episode/{{ tdata['show_key'] }}/{{ tdata['episode_key'] }}/?speaker={{ speaker['speaker'] }}&search_type=advanced" 
-										class="alert-link" >{{ speaker['scene_count'] }}</a></td>
-								<td><a href="/web/episode/{{ tdata['show_key'] }}/{{ tdata['episode_key'] }}/?speaker={{ speaker['speaker'] }}&search_type=advanced" 
-									class="alert-link" >{{ speaker['line_count'] }}</a></td>
-								<td>{{ speaker['word_count'] }}</td>
-							{% endif %}
-							</tr>
+							</small></p>
 						{% endfor %}
-						</tbody>
-					</table>
-				</div>
-			</div>
-			<div class="col-2">
-				<h3>Keywords</h3>
-				<div class="overflow-scroll" style="max-height: 600px;">
-					<table class="table table-hover table-striped table-fit">
-						<thead>
-							<tr class="table-primary">
-								<th scope="col">Term</th>
-								<th scope="col">Score</th>
-							</tr>
-						</thead>
-						<tbody>
-							{% for keyword in tdata['keywords'] %}
-							<tr class="table-secondary">
-								<th scope="row">{{  keyword['term'] }}</th>
-								<td>{{ keyword['score'] }}</td>
-							</tr>
+						</div>
+					</div>
+					{% endif %}
+				<!-- end subset of transcript matching search query -->
+				{% else %}
+				<!-- begin full transcript display -->
+					<h3><strong>{{ tdata['episode']['scene_count'] }}</strong> scenes / 
+						<strong>{{ tdata['speaker_counts'][0]['line_count'] }}</strong> lines /
+						<strong>{{ tdata['speaker_counts'][0]['word_count'] }}</strong> words
+					</h3>
+					<br/>
+					{% for scene in tdata['episode']['scenes'] %}
+					<div class="card text-white bg-success mb-3 w-90">
+						<div class="card-header">{{ scene['location'] }}</div>
+						<div class="card-body">
+							{% for scene_event in scene['scene_events'] %}
+							<p>
+								{% if scene_event['context_info'] %}
+									[{{ scene_event['context_info']|safe }}] 
+								{% endif %}
+								{% if scene_event['spoken_by'] %}
+									<strong>{{ scene_event['spoken_by']|safe }}</strong>: {{ scene_event['dialog']|safe }}
+								{% endif %}
+							</p>
 							{% endfor %}
-						</tbody>
-					</table>
-				</div>
+						</div>
+					</div>
+					{% endfor %}
+				{% endif %}
+				<!-- end full transcript display -->
 			</div>
-			<div class="col-5">
-				<h3>Similar episodes</h3>
-				<div class="overflow-scroll" style="max-height: 600px;">
-					<table class="table table-hover table-striped table-fit">
-						<thead>
-							<tr class="table-success">
-								<th scope="col">Title</th>
-								<th scope="col">Season</th>
-								<th scope="col">Episode</th>
-								<th scope="col">Air date</th>
-								<th scope="col">Score</th>
-							</tr>
-						</thead>
-						<tbody>
-							{% for sim_ep in tdata['similar_episodes'] %}
-							<tr class="table-light">
-								<th scope="row"><a href="/web/episode/{{ sim_ep['show_key'] }}/{{ sim_ep['episode_key'] }}">{{ sim_ep['title'] }}</a></th>
-								<td>{{ sim_ep['season'] }}</td>
-								<td>{{ sim_ep['sequence_in_season'] }}</td>
-								<td>{{ sim_ep['air_date'] }}</td>
-								<td>{{ sim_ep['score'] }}</td>
-							</tr>
-							{% endfor %}
-						</tbody>
-					</table>
+
+			<!-- begin statistics frames -->
+			<div class="col-6">
+				<div class="row">
+					<div class="col-4">
+						<h3>Locations</h3>
+						<div class="overflow-scroll" style="max-height: 500px;">
+							<table class="table table-hover table-striped table-fit">
+								<thead>
+									<tr class="table-primary">
+										<th scope="col">Location</th>
+										<th scope="col">Scenes</th>
+									</tr>
+								</thead>
+								<tbody>
+									{% for location, count in tdata['locations_by_scene'].items() %}
+									<tr class="table-secondary">
+										<th scope="row">{{ location }}</th>
+										<td>
+										{% if location == 'TOTAL' %}
+											<strong>{{ count }}</strong>
+										{% else %}
+											<a href="/web/episode/{{ tdata['show_key'] }}/{{ tdata['episode_key'] }}/?location={{ location }}&search_type=advanced" 
+												class="alert-link" >{{ count }}</a>
+										{% endif %}
+										</td>
+									</tr>
+									{% endfor %}
+								</tbody>
+							</table>
+						</div>
+					</div>
+					<div class="col-5">
+						<h3>Characters</h3>
+						<div class="overflow-scroll" style="max-height: 500px;">
+							<table class="table table-hover table-striped table-fit">
+								<thead>
+									<tr class="table-success">
+										<th scope="col">Speaker</th>
+										<th scope="col">Scenes</th>
+										<th scope="col">Lines</th>
+										<th scope="col">Words</th>
+									</tr>
+								</thead>
+								<tbody>
+								{% for speaker in tdata['speaker_counts'] %}
+									<tr class="table-secondary">
+									{% if speaker['speaker'] == '_ALL_' %}
+										<th scope="row">[ALL]</th>
+										<td><strong>{{ speaker['scene_count'] }}</strong></td>
+										<td><strong>{{ speaker['line_count'] }}</strong></td>
+										<td><strong>{{ speaker['word_count'] }}</strong></td>
+									{% else %}
+										<th scope="row">
+											<a href="/web/character/{{ tdata['show_key'] }}/{{ speaker['speaker'] }}" 
+												class="alert-link">{{ speaker['speaker'] }}</a></th>
+										<td><a href="/web/episode/{{ tdata['show_key'] }}/{{ tdata['episode_key'] }}/?speaker={{ speaker['speaker'] }}&search_type=advanced" 
+												class="alert-link">{{ speaker['scene_count'] }}</a></td>
+										<td><a href="/web/episode/{{ tdata['show_key'] }}/{{ tdata['episode_key'] }}/?speaker={{ speaker['speaker'] }}&search_type=advanced" 
+											class="alert-link">{{ speaker['line_count'] }}</a></td>
+										<td>{{ speaker['word_count'] }}</td>
+									{% endif %}
+									</tr>
+								{% endfor %}
+								</tbody>
+							</table>
+						</div>
+					</div>
+					<div class="col-3">
+						<h3>Keywords</h3>
+						<div class="overflow-scroll" style="max-height: 500px;">
+							<table class="table table-hover table-striped table-fit">
+								<thead>
+									<tr class="table-primary">
+										<th scope="col">Term</th>
+										<th scope="col">Score</th>
+									</tr>
+								</thead>
+								<tbody>
+									{% for keyword in tdata['keywords'] %}
+									<tr class="table-secondary">
+										<th scope="row">{{  keyword['term'] }}</th>
+										<td>{{ '%0.2f'|format(keyword['score']|float) }}</td>
+									</tr>
+									{% endfor %}
+								</tbody>
+							</table>
+						</div>
+					</div>
+				</div>
+				<p>&nbsp;</p>
+				<div class="row">
+					<div class="col-12">
+						<h3>Similar episodes - Elasticsearch MLT</h3>
+						<div class="overflow-scroll" style="max-height: 600px;">
+							<table class="table table-hover table-striped table-fit">
+								<thead>
+									<tr class="table-success">
+										<th scope="col">Title</th>
+										<th scope="col">Season</th>
+										<th scope="col">Episode</th>
+										<th scope="col">Focal characters</th>
+										<th scope="col">Focal locations</th>
+										<th scope="col">Air date</th>
+										<th scope="col">Score</th>
+									</tr>
+								</thead>
+								<tbody>
+									{% for sim_ep in tdata['mlt_tfidf'] %}
+									<tr class="table-light">
+										<th scope="row"><a href="/web/episode/{{ sim_ep['show_key'] }}/{{ sim_ep['episode_key'] }}">{{ sim_ep['title'] }}</a></th>
+										<td>{{ sim_ep['season'] }}</td>
+										<td>{{ sim_ep['sequence_in_season'] }}</td>
+										<td>{{ sim_ep['focal_speakers']|join(', ') }}</td>
+										<td>{{ sim_ep['focal_locations']|join(', ') }}</td>
+										<td>{{ sim_ep['air_date']|truncate(10,true,'') }}</td>
+										<td>{{ '%0.2f'|format(sim_ep['score']|float) }}</td>
+									</tr>
+									{% endfor %}
+								</tbody>
+							</table>
+						</div>
+					</div>
+				</div>
+				<p>&nbsp;</p>
+				<div class="row">
+					<div class="col-12">
+						<h3>Similar episodes - OpenAI cosine similarity</h3>
+						<div class="overflow-scroll" style="max-height: 600px;">
+							<table class="table table-hover table-striped table-fit">
+								<thead>
+									<tr class="table-success">
+										<th scope="col">Title</th>
+										<th scope="col">Season</th>
+										<th scope="col">Episode</th>
+										<th scope="col">Focal characters</th>
+										<th scope="col">Focal locations</th>
+										<th scope="col">Air date</th>
+										<th scope="col">Score</th>
+									</tr>
+								</thead>
+								<tbody>
+									{% for sim_ep in tdata['mlt_embeddings'] %}
+									<tr class="table-secondary">
+										<th scope="row"><a href="/web/episode/{{ sim_ep['show_key'] }}/{{ sim_ep['episode_key'] }}" 
+											class="alert-link">{{ sim_ep['title'] }}</a></th>
+										<td>{{ sim_ep['season'] }}</td>
+										<td>{{ sim_ep['sequence_in_season'] }}</td>
+										<td>{{ sim_ep['focal_speakers']|join(', ') }}</td>
+										<td>{{ sim_ep['focal_locations']|join(', ') }}</td>
+										<td>{{ sim_ep['air_date']|truncate(10,true,'') }}</td>
+										<td>{{ '%0.2f'|format(sim_ep['agg_score']|float) }}</td>
+									</tr>
+									{% endfor %}
+								</tbody>
+							</table>
+						</div>
+					</div>
 				</div>
 			</div>
 		</div>
 		<p>&nbsp;</p>
 		<!-- end statistics frames -->
 
-		<!-- begin in-episode search form -->
-		<h3>In-episode search</h3>
-		<br/>
-		<form action="/web/episode/{{ tdata['show_key'] }}/{{ tdata['episode_key'] }}" method="GET">
-            <!-- https://getbootstrap.com/docs/5.0/components/navs-tabs/#javascript-behavior -->
-            <nav>
-                <div class="nav nav-tabs" id="nav-tab" role="tablist">
-                    <button class="nav-link{% if tdata['search_type']=='' or tdata['search_type']=='general' %} active{% endif %}" id="nav-general-tab" 
-							data-bs-toggle="tab" data-bs-target="#nav-general" type="button" role="tab" aria-controls="nav-general" aria-selected="true">
-                        Keyword search
-                    </button>
-                    <button class="nav-link{% if tdata['search_type']=='advanced' %} active{% endif %}" id="nav-advanced-tab" 
-							data-bs-toggle="tab" data-bs-target="#nav-advanced" type="button" role="tab" aria-controls="nav-advanced" aria-selected="false">
-                        Filter search
-                    </button>
-                    <button class="nav-link{% if tdata['search_type']=='advanced_multi_speaker' %} active{% endif %}" id="nav-advanced-multi-character-tab" 
-							data-bs-toggle="tab" data-bs-target="#nav-advanced-multi-character" type="button" role="tab" aria-controls="nav-advanced-multi-character" aria-selected="false">
-                        Multi-character search
-                    </button>
-					<button class="nav-link" id="nav-reset-tab" href="/web/episode/{{ tdata['show_key'] }}/{{ tdata['episode_key'] }}">
-                        Clear search/reload transcript
-                    </button>
-                </div>
-            </nav>
-            <br/>
-            <div class="tab-content" id="nav-tabContent">
-                <div class="tab-pane fade{% if tdata['search_type']=='' or tdata['search_type']=='general' %} show active{% endif %}" id="nav-general" role="tabpanel" aria-labelledby="nav-general-tab">
-                    <div class="col-9">
-                        <div class="row input-group">
-                            <div class="col-2">
-                                <label class="col-form-label">Find lines containing:</label>
-                            </div>
-                            <div class="col-5"> 
-                                <input type="text" class="form-control" name="qt" value="{{ tdata['qt'] }}" id="qtInput">
-                            </div>
-                            <div class="col-2">
-                                <button type="submit" class="btn btn-primary" name="search_type" value="general">Search</button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="tab-pane fade{% if tdata['search_type']=='advanced' %} show active{% endif %}" id="nav-advanced" role="tabpanel" aria-labelledby="nav-advanced-tab">
-                    <div class="col-8">
-                        <div class="row input-group">
-                            <div class="col-2">
-                                <label class="col-form-label">By character:</label>
-                            </div>
-                            <div class="col-6"> 
-                                <input type="text" class="form-control" name="speaker" value="{{ tdata['speaker'] }}" id="speakerInput">
-                            </div>
-                        </div>
-						<div class="row input-group">
-                            <div class="col-2">
-                                <label class="col-form-label">By dialogue:</label>
-                            </div>
-                            <div class="col-6"> 
-                                <input type="text" class="form-control" name="dialog" value="{{ tdata['dialog'] }}" id="dialogInput">
-                            </div>
-                        </div>                        
-                        <div class="row input-group">
-                            <div class="col-2">
-                                <label class="col-form-label">By location:</label>
-                            </div>
-                            <div class="col-6"> 
-                                <input type="text" class="form-control" name="location" value="{{ tdata['location'] }}" id="locationInput">
-                            </div>
-                        </div>
-                        <br/>
-                        <div class="row input-group">
-                            <div class="col-8">
-                                <button type="submit" class="btn btn-primary" name="search_type" value="advanced">Search</button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="tab-pane fade{% if tdata['search_type']=='advanced_multi_speaker' %} show active{% endif %}" id="nav-advanced-multi-character" role="tabpanel" aria-labelledby="nav-advanced-multi-character-tab">
-                    <div class="col-8">
-                        <div class="row input-group">
-                            <div class="col-2">
-                                <label class="col-form-label">By characters:</label>
-                            </div>
-                            <div class="col-6"> 
-                                <input type="text" class="form-control" name="speakers" value="{{ tdata['speakers'] }}" id="speakersInput">
-                            </div>
-                        </div>                              
-                        <div class="row input-group">
-                            <div class="col-2">
-                                <label class="col-form-label">By location:</label>
-                            </div>
-                            <div class="col-6"> 
-                                <input type="text" class="form-control" name="locationAMS" value="{{ tdata['locationAMS'] }}" id="locationAMSInput">
-                            </div>
-                        </div>
-                        <br/>
-                        <div class="row input-group">
-                            <div class="col-8">
-                                <button type="submit" class="btn btn-primary" name="search_type" value="advanced_multi_speaker">Search</button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <br/>
-        </form>
-        <br/>
-		<!-- end in-episode search form -->
-
-		<!-- begin search result count summary -->
-		{% if tdata['search_type'] != '' %}
-			<h3><strong>{{ tdata['scene_match_count'] }}</strong> scenes / 
-				<strong>{{ tdata['scene_event_match_count'] }}</strong> lines matching 
-        	{% if tdata['search_type'] == 'general' %}
-				query: <strong class="gold">"{{ tdata['qt'] }}"</strong>
-			{% endif %}
-            {% if tdata['search_type'] == 'advanced' %}
-            	{% if tdata['speaker'] %} character: <strong class="gold">"{{ tdata['speaker'] }}"</strong>{% endif %}
-            	{% if tdata['dialog'] %} dialogue: <strong class="gold">"{{ tdata['dialog'] }}"</strong>{% endif %}
-            	{% if tdata['location'] %} location: <strong class="gold">"{{ tdata['location'] }}"</strong>{% endif %}
-            	{% if tdata['season'] %}, Season <strong>{{ tdata['season'] }}</strong>{% endif %}
-        	{% endif %}
-        	{% if tdata['search_type'] == 'advanced_multi_speaker' %}
-            	{% if tdata['speakers'] %} characters: <strong class="gold">"{{ tdata['speakers'] }}"</strong>{% endif %}
-            	{% if tdata['locationAMS'] %} location: <strong class="gold">"{{ tdata['locationAMS'] }}"</strong>{% endif %}
-			{% endif %}
-            {% if tdata['season'] %}, Season <strong>{{ tdata['season'] }}</strong>{% endif %}
-        	</h3>
-        {% endif %}
-		<p>&nbsp;</p>
-		<!-- end search result count summary -->
-
-		<!-- begin subset of transcript matching search query -->
-		{% if tdata['search_type'] != '' %}
-			{% if tdata['episode_match'] and tdata['episode_match']['scenes'] %}
-			<div class="card text-white bg-success mb-3 w-75">
-				<div class="card-body">
-				{% for scene in tdata['episode_match']['scenes'] %}
-					<hr>
-					<p>[scene {{ scene['sequence'] }}] <strong>{{ scene['location']|safe }}</strong></p>
-					<p><small>
-					{% for scene_event in scene['scene_events'] %}
-						[line {{ scene_event['sequence'] }}] 
-						{% if scene_event['context_info'] %}
-							[{{ scene_event['context_info']|safe }}] 
-						{% endif %}
-						{% if scene_event['spoken_by'] %}
-							<strong>{{ scene_event['spoken_by']|safe }}</strong>: {{ scene_event['dialog']|safe }}
-						{% endif %}
-						<br/>
-					{% endfor %}
-					</small></p>
-				{% endfor %}
-				</div>
-			</div>
-			{% endif %}
-		<!-- end subset of transcript matching search query -->
-		{% else %}
-		<!-- begin full transcript display -->
-			<h3><strong>{{ tdata['episode']['scene_count'] }}</strong> scenes / 
-				<strong>{{ tdata['speaker_counts'][0]['line_count'] }}</strong> lines /
-				<strong>{{ tdata['speaker_counts'][0]['word_count'] }}</strong> words
-			</h3>
-			<p>&nbsp;</p>
-			{% for scene in tdata['episode']['scenes'] %}
-			<div class="card text-white bg-success mb-3 w-75">
-				<div class="card-header">{{ scene['location'] }}</div>
-				<div class="card-body">
-					{% for scene_event in scene['scene_events'] %}
-					<p>
-						{% if scene_event['context_info'] %}
-							[{{ scene_event['context_info']|safe }}] 
-						{% endif %}
-						{% if scene_event['spoken_by'] %}
-							<strong>{{ scene_event['spoken_by']|safe }}</strong>: {{ scene_event['dialog']|safe }}
-						{% endif %}
-					</p>
-					{% endfor %}
-				</div>
-			</div>
-			{% endfor %}
-		{% endif %}
-		<!-- end full transcript display -->
+		
 
 	</div>
 {% endblock %} 

--- a/app/templates/episodeListing.html
+++ b/app/templates/episodeListing.html
@@ -13,7 +13,7 @@
 
         {% for episode in tdata['episode_matches'] %}
         <div class="card text-white bg-success mb-3 w-75">
-            <div class="card-header">Season {{ episode['season'] }}, Episode {{ episode['sequence_in_season'] }} ({{ episode['air_date'] }})</div>
+            <div class="card-header">Season {{ episode['season'] }}, Episode {{ episode['sequence_in_season'] }} ({{ episode['air_date']|truncate(10,true,'') }})</div>
             <div class="card-body">
                 <h5 class="card-title">
                     <button type="button" class="btn btn-primary">{{ '%0.2f'| format(episode['agg_score']|float)}}</button>&nbsp;

--- a/app/templates/episodeSearch.html
+++ b/app/templates/episodeSearch.html
@@ -221,7 +221,7 @@
             <!-- other search_types -->
             {% for episode in tdata['episode_matches'] %}
             <div class="card text-white bg-success mb-3 w-75">
-                <div class="card-header">Season {{ episode['season'] }}, Episode {{ episode['sequence_in_season'] }} ({{ episode['air_date'] }})</div>
+                <div class="card-header">Season {{ episode['season'] }}, Episode {{ episode['sequence_in_season'] }} ({{ episode['air_date']|truncate(10,true,'') }})</div>
                 <div class="card-body">
                     <h5 class="card-title">
                         <button type="button" class="btn btn-primary">{{ '%0.2f'|format(episode['agg_score']|float) }}</button>&nbsp;&nbsp;

--- a/app/templates/show.html
+++ b/app/templates/show.html
@@ -20,6 +20,7 @@
                     <table class="table accordion">
                         <thead>
                             <tr class="table-primary">
+                                <th scope="col">&nbsp;</th>
                                 <th scope="col">Season</th>
                                 <th scope="col">Episodes</th>
                                 <th scope="col">Dates</th>
@@ -33,7 +34,8 @@
                         <tbody>
                             {% for season, season_stats in tdata['stats_by_season'].items() %}
                             <tr class="table-secondary" data-bs-toggle="collapse" data-bs-target="#expandSeason{{ season }}">
-                                <th scope="row">{{ season }}<i class="bi bi-chevron-down"></i></th>
+                                <th scope="row" class="bi bi-chevron-down">[+]</th>
+                                <td>{{ season }}</td>
                                 <td>{{ tdata['episodes_by_season'][season]|length }}</td>
                                 <td>{{ season_stats['air_date_range'] }}</td>
                                 <td>{{ season_stats['scene_count'] }}</td>
@@ -160,7 +162,7 @@
                                         <a class="alert-link" href="/web/character/{{ tdata['show_key'] }}/{{ speaker['speaker'] }}">{{ speaker['speaker'] }}</a>
                                     {% endif %}
                                 </th>
-                                <td>...</td>
+                                <td>{{ speaker['season_count'] }}</td>
                                 <td>
                                     {% if speaker['speaker'] == '_ALL_' %}
                                         {{ speaker['episode_count'] }}

--- a/app/templates/show.html
+++ b/app/templates/show.html
@@ -34,7 +34,7 @@
                         <tbody>
                             {% for season, season_stats in tdata['stats_by_season'].items() %}
                             <tr class="table-secondary" data-bs-toggle="collapse" data-bs-target="#expandSeason{{ season }}">
-                                <th scope="row" class="bi bi-chevron-down">[+]</th>
+                                <td>[+]</td>
                                 <td>{{ season }}</td>
                                 <td>{{ tdata['episodes_by_season'][season]|length }}</td>
                                 <td>{{ season_stats['air_date_range'] }}</td>
@@ -45,7 +45,7 @@
                                 <td>{{ season_stats['location_count'] }}</td>
                             </tr>
                             <tr class="collapse accordion-collapse" id="expandSeason{{ season }}" data-bs-parent=".table">
-                                <td colspan="8">
+                                <td colspan="9">
                                     <div class="overflow-scroll" style="max-height: 500px;">
                                         <div class="row">                                     
                                             <div class="col-8">
@@ -193,12 +193,12 @@
                             </tr>
                         </thead>
                         <tbody>
-                            {% for location, count in tdata['locations_by_scene'].items() %}
+                            {% for location in tdata['location_counts'] %}
                             <tr class="table-secondary">
-                                <th scope="row">{{ location }}</th>
-                                <td>...</td>
-                                <td>...</td>
-                                <td>{{ count }}</td>
+                                <th scope="row">{{ location['location'] }}</th>
+                                <td>{{ location['season_count'] }}</td>
+                                <td>{{ location['episode_count'] }}</td>
+                                <td>{{ location['scene_count'] }}</td>
                             </tr>
                             {% endfor %}
                         </tbody>

--- a/app/templates/show.html
+++ b/app/templates/show.html
@@ -125,7 +125,7 @@
 
         <div class="row">
             <div class="col-4">
-                <h3>ML playground:mKMeans</h3>
+                <h3>ML playground: KMeans</h3>
                 <a href="/tsp_dash">Plotly</a> (interactive) or Matplotlib (fixed: select # clusters: <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=2">2</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=3">3</a> 
                     <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=4">4</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=5">5</a> 
                     <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=6">6</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=7">7</a> 

--- a/app/templates/show.html
+++ b/app/templates/show.html
@@ -128,11 +128,15 @@
         <div class="row">
             <div class="col-4">
                 <h3>ML playground: KMeans</h3>
-                <a href="/tsp_dash">Plotly</a> (interactive) or Matplotlib (fixed: select # clusters: <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=2">2</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=3">3</a> 
-                    <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=4">4</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=5">5</a> 
-                    <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=6">6</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=7">7</a> 
-                    <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=8">8</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=9">9</a> 
-                    <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=10">10</a>)
+                <ul>
+                    <li><a href="/tsp_dash">Plotly</a> - interactive</li>
+                    <li>Matplotlib - select # clusters: <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=2">2</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=3">3</a> 
+                        <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=4">4</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=5">5</a> 
+                        <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=6">6</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=7">7</a> 
+                        <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=8">8</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=9">9</a> 
+                        <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=10">10</a>
+                    </li>
+                </ul>
             </div>
         </div>
         <br/>

--- a/app/web/web_router.py
+++ b/app/web/web_router.py
@@ -25,8 +25,11 @@ async def show_page(request: Request, show_key: ShowKey):
 	tdata['header'] = 'show'
 	tdata['show_key'] = show_key.value
 
-	locations_by_scene = await esr.agg_scenes_by_location(show_key)
-	tdata['locations_by_scene'] = locations_by_scene['scenes_by_location']
+	# locations_by_scene = await esr.agg_scenes_by_location(show_key)
+	# tdata['locations_by_scene'] = locations_by_scene['scenes_by_location']
+
+	location_counts = await esr.composite_location_aggs(show_key)
+	tdata['location_counts'] = location_counts['location_agg_composite']
 
 	speaker_counts = await esr.composite_speaker_aggs(show_key)
 	tdata['speaker_counts'] = speaker_counts['speaker_agg_composite']

--- a/app/web/web_router.py
+++ b/app/web/web_router.py
@@ -87,8 +87,11 @@ async def episode_page(request: Request, show_key: ShowKey, episode_key: str, se
 	keywords = await esr.keywords_by_episode(show_key, episode_key, exclude_speakers=True)
 	tdata['keywords'] = keywords['keywords']
 	
-	mlt = await esr.more_like_this(show_key, episode_key)
-	tdata['similar_episodes'] = mlt['similar_episodes']
+	mlt_tfidf = await esr.more_like_this(show_key, episode_key)
+	tdata['mlt_tfidf'] = mlt_tfidf['similar_episodes']
+
+	mlt_embeddings = esr.mlt_vector_search(show_key, episode_key)
+	tdata['mlt_embeddings'] = mlt_embeddings['matches'][:30]
 
 	###### IN-EPISODE SEARCH ######
 
@@ -126,8 +129,12 @@ async def episode_page(request: Request, show_key: ShowKey, episode_key: str, se
 		else:
 			matches = await esr.search_scene_events(show_key, episode_key=episode_key, speaker=speaker, dialog=dialog, location=location)
 			tdata['scene_event_match_count'] = matches['scene_event_count']
-		tdata['episode_match'] = matches['matches'][0]
-		tdata['scene_match_count'] = matches['scene_count']
+		if matches['matches']:
+			tdata['episode_match'] = matches['matches'][0]
+			tdata['scene_match_count'] = matches['scene_count']
+		else:
+			tdata['episode_match'] = ''
+			tdata['scene_match_count'] = 0
 		
 	elif search_type == 'advanced_multi_speaker':
 		if speakers:


### PR DESCRIPTION
* add embeddings mlt to episode page, rearrange page to put transcript text in body and data/listings in side panel
* add /esr/agg_seasons_by_speaker endpoint, incorporate it into speaker_agg_composite behind show.html page
* add /esr/composite_location_aggs, /esr/agg_seasons_by_location, and /esr/agg_episodes_by_location endpoints and combine into sorted location_agg_composite dict behind show.html page
* fill in speaker scene_event and word count columns per episode behind character.html page