### PR TITLE
Much ado about plotly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 .DS_Store
 .vscode/
 *_notes.txt
+/data/*
 /database/backups
 /source
 /venv

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ As of this writing, properly ingested/normalized show transcripts can:
 * `BeautifulSoup`: text parser for transforming raw HTML to normalized objects 
 * `Pandas` / `NumPy` / `Scikit-learn` / `NLTK`: data / text analytics / ML tool kits
 * `Word2Vec` / `OpenAI`: pre-trained language / embedding models 
+* `Plotly` / `Dash` : data visualization and associated web delivery frameworks
 
 # Setup and run 
 
@@ -250,6 +251,15 @@ ES Reader `/esr` endpoints provide most of the core functionality of the project
 ### 'Web' endpoints: render web pages 
 
 Webpage-rendering endpoints are 'front-end' consumers of the other 'back-end' endpoints, specifically of the 'ES Reader' endpoints. These 'Web' endpoints generate combinations of `/esr` requests, package up the results, and feed them into HTML templates that offer some bare-bones UI functionality.
+
+
+## Plotly figures
+
+TODO
+
+### Publishing animations
+
+The `Dash` web framework does not support animation rendering, so animations must be generated and served independently as fully-baked html pages. To generate an animation html page, run `python publish_animation.py` script from project root, incorporating parameters as defined in script. The generated animation html file will be saved to the output_path noted in the logs.
 
 
 ## Analytics

--- a/app/dash/episode_gantt_chart.py
+++ b/app/dash/episode_gantt_chart.py
@@ -1,0 +1,55 @@
+import dash_bootstrap_components as dbc
+from dash import dcc, html
+
+from app.dash.components import navbar
+
+
+# TODO this is almost identical to `speaker_3d_network_graph` and should probably be templatized
+def generate_content(episode_dropdown_options: list, episode_key: str = None) -> html.Div:
+    if not episode_key:
+        episode_key = '218'
+
+    content = html.Div([
+        navbar,
+        dbc.Card(className="bg-dark", children=[
+            dbc.CardBody([
+                dbc.Row([
+                    html.H3(children=["Character dialog gantt chart for ", html.Span(id='show-key-display5')]),
+                    dbc.Col(md=2, children=[
+                        html.Div([
+                            "Show: ",
+                            dcc.Dropdown(
+                                id="show-key",
+                                options=[
+                                    {'label': 'TNG', 'value': 'TNG'},
+                                    {'label': 'GoT', 'value': 'GoT'},
+                                ], 
+                                value='TNG',
+                            )
+                        ]),
+                    ]),
+                    dbc.Col(md=2, children=[
+                        html.Div([
+                            "Episode key: ",
+                            dcc.Dropdown(
+                                id="episode-key",
+                                options=episode_dropdown_options,
+                                value=episode_key,
+                            )
+                        ]),
+                    ]),
+                ]),
+                html.Br(),
+                dbc.Row(justify="evenly", children=[
+                    dcc.Graph(id="episode-dialog-timeline"),
+                ]),
+                html.Br(),
+                dbc.Row(justify="evenly", children=[
+                    dcc.Graph(id="episode-location-timeline"),
+                ]),
+                html.Br(),
+            ]),
+        ])
+    ])
+
+    return content

--- a/app/dash/location_line_chart.py
+++ b/app/dash/location_line_chart.py
@@ -1,0 +1,64 @@
+import dash_bootstrap_components as dbc
+from dash import dcc, html
+
+from app.dash.components import navbar
+
+
+content = html.Div([
+    navbar,
+    dbc.Card(className="bg-dark", children=[
+        dbc.CardBody([
+            dbc.Row([
+                html.H3(children=["Location comparison chart for ", html.Span(id='show-key-display8')]),
+                dbc.Col(md=2, children=[
+                    html.Div([
+                        "Show: ",
+                        dcc.Dropdown(
+                            id="show-key",
+                            options=[
+                                {'label': 'TNG', 'value': 'TNG'},
+                                {'label': 'GoT', 'value': 'GoT'},
+                            ], 
+                            value='TNG',
+                        )
+                    ]),
+                ]),
+                dbc.Col(md=2, children=[
+                    html.Div([
+                        "Span granularity: ",
+                        dcc.Dropdown(
+                            id="span-granularity",
+                            options=['scene', 'episode'],
+                            value='scene',
+                        )
+                    ]),
+                ]),
+                dbc.Col(md=2, children=[
+                    html.Div([
+                        "Aggregate? ",
+                        dcc.Dropdown(
+                            id="aggregate-ratio",
+                            options=['True', 'False'],
+                            value='True',
+                        )
+                    ]),
+                ]),
+                dbc.Col(md=2, children=[
+                    html.Div([
+                        "Season ",
+                        dcc.Dropdown(
+                            id="season",
+                            options=['All', '1', '2', '3', '4', '5', '6' ,'7'],
+                            value='All',
+                        )
+                    ]),
+                ]),
+            ]),
+            html.Br(),
+            dbc.Row(justify="evenly", children=[
+                dcc.Graph(id="location-line-chart"),
+            ]),
+            html.Br(),
+        ]),
+    ])
+])

--- a/app/dash/series_search_results_gantt.py
+++ b/app/dash/series_search_results_gantt.py
@@ -26,14 +26,28 @@ content = html.Div([
                 dbc.Col(md=2, children=[
                     html.Div([
                         "Query term: ",
+                        html.Br(),
                         dcc.Input(
                             id="qt",
                             type="text",
                             placeholder="enter text to search",
+                            size=30,
+                            autoFocus=True,
+                            debounce=True,
+                            # required=True,
                         )
                     ]),
                 ]),
-                # html.Button('Search', id='qt-submit'),
+                # NOTE: I believe this button is a placebo: it's a call to action, but simply exiting the qt field invokes the callback 
+                dbc.Col(md=2, children=[
+                    html.Div([
+                        html.Br(),
+                        html.Button(
+                            'Search', 
+                            id='qt-submit',
+                        ),
+                    ]),
+                ]),
             ]),
             html.Br(),
             dbc.Row(justify="evenly", children=[

--- a/app/dash/series_search_results_gantt.py
+++ b/app/dash/series_search_results_gantt.py
@@ -1,0 +1,45 @@
+import dash_bootstrap_components as dbc
+from dash import dcc, html
+
+from app.dash.components import navbar
+
+
+content = html.Div([
+    navbar,
+    dbc.Card(className="bg-dark", children=[
+        dbc.CardBody([
+            dbc.Row([
+                html.H3(children=["Search results gantt chart visualization for query ", html.Span(id='qt-display'), " in ", html.Span(id='show-key-display9')]),
+                dbc.Col(md=2, children=[
+                    html.Div([
+                        "Show: ",
+                        dcc.Dropdown(
+                            id="show-key",
+                            options=[
+                                {'label': 'TNG', 'value': 'TNG'},
+                                {'label': 'GoT', 'value': 'GoT'},
+                            ], 
+                            value='TNG',
+                        )
+                    ]),
+                ]),
+                dbc.Col(md=2, children=[
+                    html.Div([
+                        "Query term: ",
+                        dcc.Input(
+                            id="qt",
+                            type="text",
+                            placeholder="enter text to search",
+                        )
+                    ]),
+                ]),
+                # html.Button('Search', id='qt-submit'),
+            ]),
+            html.Br(),
+            dbc.Row(justify="evenly", children=[
+                dcc.Graph(id="series-search-results-gantt"),
+            ]),
+            html.Br(),
+        ]),
+    ])
+])

--- a/app/dash/show_gantt_chart.py
+++ b/app/dash/show_gantt_chart.py
@@ -29,6 +29,10 @@ content = html.Div([
                 dcc.Graph(id="show-speaker-gantt"),
             ]),
             html.Br(),
+            dbc.Row(justify="evenly", children=[
+                dcc.Graph(id="show-location-gantt"),
+            ]),
+            html.Br(),
         ]),
     ])
 ])

--- a/app/dash/show_gantt_chart.py
+++ b/app/dash/show_gantt_chart.py
@@ -4,52 +4,31 @@ from dash import dcc, html
 from app.dash.components import navbar
 
 
-# TODO this is almost identical to `speaker_3d_network_graph` and should probably be templatized
-def generate_content(episode_dropdown_options: list, episode_key: str = None) -> html.Div:
-    if not episode_key:
-        episode_key = '218'
-
-    content = html.Div([
-        navbar,
-        dbc.Card(className="bg-dark", children=[
-            dbc.CardBody([
-                dbc.Row([
-                    html.H3(children=["Character dialog gantt chart for ", html.Span(id='show-key-display5')]),
-                    dbc.Col(md=2, children=[
-                        html.Div([
-                            "Show: ",
-                            dcc.Dropdown(
-                                id="show-key",
-                                options=[
-                                    {'label': 'TNG', 'value': 'TNG'},
-                                    {'label': 'GoT', 'value': 'GoT'},
-                                ], 
-                                value='TNG',
-                            )
-                        ]),
-                    ]),
-                    dbc.Col(md=2, children=[
-                        html.Div([
-                            "Episode key: ",
-                            dcc.Dropdown(
-                                id="episode-key",
-                                options=episode_dropdown_options,
-                                value=episode_key,
-                            )
-                        ]),
+content = html.Div([
+    navbar,
+    dbc.Card(className="bg-dark", children=[
+        dbc.CardBody([
+            dbc.Row([
+                html.H3(children=["Character continuity gantt chart for ", html.Span(id='show-key-display6')]),
+                dbc.Col(md=2, children=[
+                    html.Div([
+                        "Show: ",
+                        dcc.Dropdown(
+                            id="show-key",
+                            options=[
+                                {'label': 'TNG', 'value': 'TNG'},
+                                {'label': 'GoT', 'value': 'GoT'},
+                            ], 
+                            value='TNG',
+                        )
                     ]),
                 ]),
-                html.Br(),
-                dbc.Row(justify="evenly", children=[
-                    dcc.Graph(id="show-dialog-timeline"),
-                ]),
-                html.Br(),
-                dbc.Row(justify="evenly", children=[
-                    dcc.Graph(id="show-location-timeline"),
-                ]),
-                html.Br(),
             ]),
-        ])
+            html.Br(),
+            dbc.Row(justify="evenly", children=[
+                dcc.Graph(id="show-speaker-gantt"),
+            ]),
+            html.Br(),
+        ]),
     ])
-
-    return content
+])

--- a/app/dash/speaker_frequency_bar_chart.py
+++ b/app/dash/speaker_frequency_bar_chart.py
@@ -62,12 +62,26 @@ content = html.Div([
                             value=1,
                         ),
                         html.Br(),
-                        dcc.Graph(id="speaker-frequency-bar-chart"),
+                        dcc.Graph(id="speaker-season-frequency-bar-chart"),
                     ]),
                 ]),
                 dbc.Col(md=6, children=[
                     html.Div([
+                        "Episode ",
                         html.Br(),
+                        dcc.Slider(
+                            id="sequence-in-season",
+                            min=1,
+                            max=25,
+                            step=None,
+                            marks={
+                                int(y): {'label': str(y), 'style': {'transform': 'rotate(45deg)', 'color': 'white'}}
+                                for y in range(1,26)
+                            },
+                            value=1,
+                        ),
+                        html.Br(),
+                        dcc.Graph(id="speaker-episode-frequency-bar-chart"),
                     ]),
                 ]),
             ]),

--- a/app/dash/speaker_frequency_bar_chart.py
+++ b/app/dash/speaker_frequency_bar_chart.py
@@ -1,0 +1,77 @@
+import dash_bootstrap_components as dbc
+from dash import dcc, html
+
+from app.dash.components import navbar
+
+
+content = html.Div([
+    navbar,
+    dbc.Card(className="bg-dark", children=[
+        dbc.CardBody([
+            dbc.Row([
+                html.H3(children=["Character frequency for ", html.Span(id='show-key-display10')]),
+                dbc.Col(md=2, children=[
+                    html.Div([
+                        "Show: ",
+                        dcc.Dropdown(
+                            id="show-key",
+                            options=[
+                                {'label': 'TNG', 'value': 'TNG'},
+                                {'label': 'GoT', 'value': 'GoT'},
+                            ], 
+                            value='TNG',
+                        )
+                    ]),
+                ]),
+                dbc.Col(md=2, children=[
+                    html.Div([
+                        "Span granularity: ",
+                        dcc.Dropdown(
+                            id="span-granularity",
+                            options=['scene', 'episode', 'line', 'word'],
+                            value='line',
+                        )
+                    ]),
+                ]),
+                # dbc.Col(md=2, children=[
+                #     html.Div([
+                #         "Aggregate? ",
+                #         dcc.Dropdown(
+                #             id="aggregate-ratio",
+                #             options=['True', 'False'],
+                #             value='True',
+                #         )
+                #     ]),
+                # ]),
+            ]),
+            html.Br(),
+            dbc.Row(justify="evenly", children=[
+                dbc.Col(md=6, children=[
+                    html.Div([
+                        "Season ",
+                        html.Br(),
+                        dcc.Slider(
+                            id="season",
+                            min=0,
+                            max=7,
+                            step=None,
+                            marks={
+                                int(y): {'label': str(y), 'style': {'transform': 'rotate(45deg)', 'color': 'white'}}
+                                for y in range(0,8)
+                            },
+                            value=1,
+                        ),
+                        html.Br(),
+                        dcc.Graph(id="speaker-frequency-bar-chart"),
+                    ]),
+                ]),
+                dbc.Col(md=6, children=[
+                    html.Div([
+                        html.Br(),
+                    ]),
+                ]),
+            ]),
+            html.Br(),
+        ]),
+    ])
+])

--- a/app/dash/speaker_line_chart.py
+++ b/app/dash/speaker_line_chart.py
@@ -1,0 +1,64 @@
+import dash_bootstrap_components as dbc
+from dash import dcc, html
+
+from app.dash.components import navbar
+
+
+content = html.Div([
+    navbar,
+    dbc.Card(className="bg-dark", children=[
+        dbc.CardBody([
+            dbc.Row([
+                html.H3(children=["Character comparison chart for ", html.Span(id='show-key-display7')]),
+                dbc.Col(md=2, children=[
+                    html.Div([
+                        "Show: ",
+                        dcc.Dropdown(
+                            id="show-key",
+                            options=[
+                                {'label': 'TNG', 'value': 'TNG'},
+                                {'label': 'GoT', 'value': 'GoT'},
+                            ], 
+                            value='TNG',
+                        )
+                    ]),
+                ]),
+                dbc.Col(md=2, children=[
+                    html.Div([
+                        "Span granularity: ",
+                        dcc.Dropdown(
+                            id="span-granularity",
+                            options=['scene', 'episode', 'line', 'word'],
+                            value='scene',
+                        )
+                    ]),
+                ]),
+                dbc.Col(md=2, children=[
+                    html.Div([
+                        "Aggregate? ",
+                        dcc.Dropdown(
+                            id="aggregate-ratio",
+                            options=['True', 'False'],
+                            value='True',
+                        )
+                    ]),
+                ]),
+                dbc.Col(md=2, children=[
+                    html.Div([
+                        "Season ",
+                        dcc.Dropdown(
+                            id="season",
+                            options=['All', '1', '2', '3', '4', '5', '6' ,'7'],
+                            value='All',
+                        )
+                    ]),
+                ]),
+            ]),
+            html.Br(),
+            dbc.Row(justify="evenly", children=[
+                dcc.Graph(id="speaker-line-chart"),
+            ]),
+            html.Br(),
+        ]),
+    ])
+])

--- a/app/dash_app.py
+++ b/app/dash_app.py
@@ -320,14 +320,15 @@ def render_series_search_results_gantt(show_key: str, qt: str, qt_submit: bool =
 
 ############ speaker-frequency-bar-chart callbacks
 @dapp.callback(
-    Output('speaker-frequency-bar-chart', 'figure'),
+    Output('speaker-season-frequency-bar-chart', 'figure'),
+    Output('speaker-episode-frequency-bar-chart', 'figure'),
     Output('show-key-display10', 'children'),
     Input('show-key', 'value'),
     Input('span-granularity', 'value'),
-    # Input('aggregate-ratio', 'value'),
-    Input('season', 'value'))    
-def render_speaker_frequency_bar_chart(show_key: str, span_granularity: str, season: str):
-    print(f'in render_speaker_frequency_bar_chart, show_key={show_key} span_granularity={span_granularity} season={season}')
+    Input('season', 'value'),
+    Input('sequence-in-season', 'value'))    
+def render_speaker_frequency_bar_chart(show_key: str, span_granularity: str, season: str, sequence_in_season: str = None):
+    print(f'in render_speaker_frequency_bar_chart, show_key={show_key} span_granularity={span_granularity} season={season} sequence_in_season={sequence_in_season}')
 
     if season in ['0', 0, 'All']:
         season = None
@@ -348,9 +349,10 @@ def render_speaker_frequency_bar_chart(show_key: str, span_granularity: str, sea
         else:
             raise Exception('Failure to render_speaker_frequency_bar_chart: unable to fetch or generate dataframe at file_path={file_path}')
     
-    speaker_frequency_bar_chart = fb.build_speaker_frequency_bar(show_key, df, span_granularity, aggregate_ratio=False, season=season)
+    speaker_season_frequency_bar_chart = fb.build_speaker_frequency_bar(show_key, df, span_granularity, aggregate_ratio=False, season=season)
+    speaker_episode_frequency_bar_chart = fb.build_speaker_frequency_bar(show_key, df, span_granularity, aggregate_ratio=True, season=season, sequence_in_season=sequence_in_season)
 
-    return speaker_frequency_bar_chart, show_key
+    return speaker_season_frequency_bar_chart, speaker_episode_frequency_bar_chart, show_key
 
 
 if __name__ == "__main__":

--- a/app/dash_app.py
+++ b/app/dash_app.py
@@ -8,8 +8,8 @@ import urllib.parse
 
 import app.dash.components as cmp
 from app.dash import (
-    episode_gantt_chart, location_line_chart, show_3d_network_graph, speaker_3d_network_graph, show_cluster_scatter, 
-    show_gantt_chart, show_network_graph, speaker_line_chart
+    episode_gantt_chart, location_line_chart, series_search_results_gantt, show_3d_network_graph, speaker_3d_network_graph, 
+    show_cluster_scatter, show_gantt_chart, show_network_graph, speaker_line_chart
 )
 import app.es.es_query_builder as esqb
 import app.es.es_response_transformer as esrt
@@ -87,6 +87,9 @@ def display_page(pathname, search):
     
     elif pathname == "/tsp_dash/location-line-chart":
         return location_line_chart.content
+    
+    elif pathname == "/tsp_dash/series-search-results-gantt":
+        return series_search_results_gantt.content
 
 
 ############ show-cluster-scatter callbacks
@@ -290,6 +293,25 @@ def render_series_location_line_chart(show_key: str, span_granularity: str, aggr
     location_line_chart = fb.build_location_line_chart(show_key, df, span_granularity, aggregate_ratio=aggregate_ratio, season=season)
 
     return location_line_chart, show_key
+
+
+############ series-search-results-gantt callbacks
+@dapp.callback(
+    Output('series-search-results-gantt', 'figure'),
+    Output('show-key-display9', 'children'),
+    Output('qt-display', 'children'),
+    Input('show-key', 'value'),
+    Input('qt', 'value'))
+    # Input('qt-submit', 'value'))    
+def render_series_search_results_gantt(show_key: str, qt: str):
+    print(f'in render_series_gantt_chart, show_key={show_key} qt={qt}')
+
+    # execute search query and filter response into series gantt charts
+    series_gantt_response = esr.generate_series_gantt_sequence(ShowKey(show_key))
+    search_response = esr.search_scene_events(ShowKey(show_key), dialog=qt)
+    series_search_results_gantt = fb.series_search_results_gantt(show_key, qt, search_response['matches'], series_gantt_response['episode_speakers_sequence'])
+
+    return series_search_results_gantt, show_key, qt
 
 
 if __name__ == "__main__":

--- a/app/dash_app.py
+++ b/app/dash_app.py
@@ -301,15 +301,16 @@ def render_series_location_line_chart(show_key: str, span_granularity: str, aggr
     Output('show-key-display9', 'children'),
     Output('qt-display', 'children'),
     Input('show-key', 'value'),
-    Input('qt', 'value'))
-    # Input('qt-submit', 'value'))    
-def render_series_search_results_gantt(show_key: str, qt: str):
-    print(f'in render_series_gantt_chart, show_key={show_key} qt={qt}')
+    Input('qt', 'value'),
+    # NOTE: I believe `qt-submit`` is a placebo: it's a call to action, but simply exiting the qt field invokes the callback
+    Input('qt-submit', 'value'))    
+def render_series_search_results_gantt(show_key: str, qt: str, qt_submit: bool = False):
+    print(f'in render_series_gantt_chart, show_key={show_key} qt={qt} qt_submit={qt_submit}')
 
     # execute search query and filter response into series gantt charts
     series_gantt_response = esr.generate_series_gantt_sequence(ShowKey(show_key))
     search_response = esr.search_scene_events(ShowKey(show_key), dialog=qt)
-    series_search_results_gantt = fb.series_search_results_gantt(show_key, qt, search_response['matches'], series_gantt_response['episode_speakers_sequence'])
+    series_search_results_gantt = fb.build_series_search_results_gantt(show_key, qt, search_response['matches'], series_gantt_response['episode_speakers_sequence'])
 
     return series_search_results_gantt, show_key, qt
 

--- a/app/dash_app.py
+++ b/app/dash_app.py
@@ -189,7 +189,7 @@ def render_episode_gantt_chart(show_key: str, episode_key: str):
 ############ show-gantt-chart callbacks
 @dapp.callback(
     Output('show-speaker-gantt', 'figure'),
-    # Output('show-location-gantt', 'figure'),
+    Output('show-location-gantt', 'figure'),
     Output('show-key-display6', 'children'),
     Input('show-key', 'value'))    
 def render_show_gantt_chart(show_key: str):
@@ -197,9 +197,10 @@ def render_show_gantt_chart(show_key: str):
 
     # generate data and build generate 3d network graph
     response = esr.show_gantt_sequence(ShowKey(show_key))
-    show_speaker_gantt = fb.build_show_gantt(show_key, response['episodes_to_speakers_sequence'])
+    show_speaker_gantt = fb.build_show_gantt(show_key, response['episode_speakers_sequence'], 'speakers')
+    show_location_gantt = fb.build_show_gantt(show_key, response['episode_locations_sequence'], 'locations')
 
-    return show_speaker_gantt, show_key
+    return show_speaker_gantt, show_location_gantt, show_key
 
 
 if __name__ == "__main__":

--- a/app/es/es_mapping.txt
+++ b/app/es/es_mapping.txt
@@ -225,5 +225,56 @@
         }
       }
     }
+  },
+  "characters": {
+    "mappings": {
+      "properties": {
+        "actor_names": {
+          "type": "keyword"
+        },
+        "alt_names": {
+          "type": "keyword"
+        },
+        "episode_count": {
+          "type": "integer"
+        },
+        "episode_embeddings": {
+          "type": "dense_vector",
+          "dims": 1536,
+          "index": true,
+          "similarity": "cosine"
+        },
+        "episodes": {
+          "type": "object"
+        },
+        "indexed_ts": {
+          "type": "date"
+        },
+        "loaded_ts": {
+          "type": "date"
+        },
+        "most_frequent_companions": {
+          "type": "object"
+        },
+        "name": {
+          "type": "keyword"
+        },
+        "scene_count": {
+          "type": "integer"
+        },
+        "scene_event_count": {
+          "type": "integer"
+        },
+        "season_count": {
+          "type": "integer"
+        },
+        "show_key": {
+          "type": "keyword"
+        },
+        "word_count": {
+          "type": "integer"
+        }
+      }
+    }
   }
 }

--- a/app/es/es_model.py
+++ b/app/es/es_model.py
@@ -104,16 +104,28 @@ class EsEpisodeTranscript(Document):
         return super().save(**kwargs)
     
 
-class Character(Document):
+class EsCharacter(Document):
     show_key = Keyword()
+    name = Keyword()
     alt_names = Keyword(multi=True)
     actor_names = Keyword(multi=True)
+    episodes = Object(multi=True)
     season_count = Integer()
+    episode_count = Integer()
     scene_count = Integer()
     scene_event_count = Integer()
     word_count = Integer()
-    most_frequent_companions = Keyword(multi=True)
+    most_frequent_companions = Object(multi=True)
     episode_embeddings = DenseVector(dims=1536, index='true', similarity='cosine')
     # episode_classifications 
     # season_classifications
     # show_classification
+    loaded_ts = Date()
+    indexed_ts = Date()
+
+    class Index:
+        name = 'characters'
+
+    def save(self, **kwargs):
+        self.indexed_ts = datetime.now()
+        return super().save(**kwargs)

--- a/app/es/es_query_builder.py
+++ b/app/es/es_query_builder.py
@@ -367,7 +367,7 @@ async def agg_seasons(show_key: str, location: str = None) -> Search:
     return s
 
 
-async def agg_episodes(show_key: str, season: str = None, location: str = None) -> Search:
+def agg_episodes(show_key: str, season: str = None, location: str = None) -> Search:
     print(f'begin agg_episodes for show_key={show_key} season={season} location={location}')
 
     s = Search(index='transcripts')
@@ -488,7 +488,7 @@ async def agg_episodes_by_speaker(show_key: str, season: str = None, location: s
     return s
 
 
-async def agg_episodes_by_location(show_key: str, season: str = None) -> Search:
+def agg_episodes_by_location(show_key: str, season: str = None) -> Search:
     print(f'begin agg_episodes_by_speaker for show_key={show_key} season={season}')
 
     s = Search(index='transcripts')
@@ -528,7 +528,7 @@ async def agg_scenes(show_key: str, season: str = None, episode_key: str = None,
     return s
 
 
-async def agg_scenes_by_location(show_key: str, season: str = None, episode_key: str = None, speaker: str = None) -> Search:
+def agg_scenes_by_location(show_key: str, season: str = None, episode_key: str = None, speaker: str = None) -> Search:
     print(f'begin agg_scenes_by_location for show_key={show_key} season={season} episode_key={episode_key} speaker={speaker}')
 
     s = Search(index='transcripts')

--- a/app/es/es_query_builder.py
+++ b/app/es/es_query_builder.py
@@ -82,6 +82,23 @@ def fetch_doc_ids(show_key: str, season: str = None) -> Search:
     return s
 
 
+def fetch_simple_episodes(show_key: str, season: str = None) -> Search:
+    print(f'begin fetch_simple_episodes for show_key={show_key} season={season}')
+
+    s = Search(index='transcripts')
+    s = s.extra(size=1000)
+
+    s = s.filter('term', show_key=show_key)
+    if season:
+        s = s.filter('term', season=season)
+
+    s = s.sort('season', 'sequence_in_season')
+
+    s = s.source(excludes=['flattened_text', 'scenes'] + VECTOR_FIELDS + RELATIONS_FIELDS)
+
+    return s
+
+
 async def search_episodes_by_title(show_key: str, qt: str) -> Search:
     print(f'begin search_episodes_by_title for show_key={show_key} qt={qt}')
 
@@ -304,36 +321,6 @@ async def search_episodes(show_key: str, season: str = None, episode_key: str = 
     return s
 
 
-def fetch_all_simple_episodes(show_key: str) -> Search:
-    print(f'begin fetch_all_simple_episodes for show_key={show_key}')
-
-    s = Search(index='transcripts')
-    s = s.extra(size=1000)
-
-    s = s.filter('term', show_key=show_key)
-
-    s = s.sort('season', 'sequence_in_season')
-
-    s = s.source(excludes=['flattened_text', 'scenes'] + VECTOR_FIELDS + RELATIONS_FIELDS)
-
-    return s
-
-
-# def list_episodes_by_season(show_key: str) -> Search:
-#     print(f'begin list_episodes_by_season for show_key={show_key}')
-
-#     s = Search(index='transcripts')
-#     s = s.extra(size=1000)
-
-#     s = s.filter('term', show_key=show_key)
-
-#     s = s.sort('season', 'sequence_in_season')
-
-#     s = s.source(excludes=['flattened_text', 'scenes'] + VECTOR_FIELDS + RELATIONS_FIELDS)
-
-#     return s
-
-
 def fetch_all_episode_relations(show_key: str, model_vendor: str, model_version: str) -> Search:
     print(f'begin fetch_all_episode_relations for show_key={show_key} model_vendor={model_vendor} model_version={model_version}')
 
@@ -509,7 +496,7 @@ def agg_episodes_by_location(show_key: str, season: str = None) -> Search:
     return s
 
 
-async def agg_scenes(show_key: str, season: str = None, episode_key: str = None, location: str = None) -> Search:
+def agg_scenes(show_key: str, season: str = None, episode_key: str = None, location: str = None) -> Search:
     print(f'begin agg_scenes for show_key={show_key} season={season} episode_key={episode_key} location={location}')
 
     s = Search(index='transcripts')
@@ -558,7 +545,7 @@ def agg_scenes_by_location(show_key: str, season: str = None, episode_key: str =
     return s
 
 
-async def agg_scenes_by_speaker(show_key: str, season: str = None, episode_key: str = None, 
+def agg_scenes_by_speaker(show_key: str, season: str = None, episode_key: str = None, 
                                 location: str = None, other_speaker: str = None) -> Search:
     print(f'begin agg_scenes_by_speaker for show_key={show_key} season={season} episode_key={episode_key} location={location} other_speaker={other_speaker}')
 
@@ -661,7 +648,7 @@ def agg_scene_events_by_speaker(show_key: str, season: str = None, episode_key: 
     return s
 
 
-async def agg_dialog_word_counts(show_key: str, season: str = None, episode_key: str = None, speaker: str = None) -> Search:
+def agg_dialog_word_counts(show_key: str, season: str = None, episode_key: str = None, speaker: str = None) -> Search:
     print(f'begin agg_dialog_word_counts for show_key={show_key} season={season} episode_key={episode_key} speaker={speaker}')
 
     s = Search(index='transcripts')

--- a/app/es/es_query_builder.py
+++ b/app/es/es_query_builder.py
@@ -159,7 +159,7 @@ async def search_scenes(show_key: str, season: str = None, episode_key: str = No
     return s
 
 
-async def search_scene_events(show_key: str, season: str = None, episode_key: str = None, speaker: str = None, dialog: str = None) -> Search:
+def search_scene_events(show_key: str, season: str = None, episode_key: str = None, speaker: str = None, dialog: str = None) -> Search:
     print(f'begin search_scene_events for show_key={show_key} season={season} episode_key={episode_key} speaker={speaker} dialog={dialog}')
     
     if not (speaker or dialog):

--- a/app/es/es_query_builder.py
+++ b/app/es/es_query_builder.py
@@ -6,7 +6,7 @@ from elasticsearch_dsl.query import MoreLikeThis
 
 from app.config import settings
 from app.es.es_metadata import STOPWORDS, VECTOR_FIELDS, RELATIONS_FIELDS
-from app.es.es_model import EsEpisodeTranscript
+from app.es.es_model import EsEpisodeTranscript, EsCharacter
 import app.es.es_read_router as esr
 from app.show_metadata import ShowKey
 
@@ -32,10 +32,15 @@ es_conn = connections.create_connection(hosts=[{'host': settings.es_host, 'port'
 # )
 
 
-async def init_transcripts_index():
+def init_transcripts_index():
     # EsEpisodeTranscript.init(using=es_client)
     EsEpisodeTranscript.init()
     es_conn.indices.put_settings(index="transcripts", body={"index": {"max_inner_result_window": 1000}})
+
+
+def init_character_index():
+    EsCharacter.init()
+    es_conn.indices.put_settings(index="characters", body={"index": {"max_inner_result_window": 1000}})
 
 
 def save_es_episode(es_episode: EsEpisodeTranscript) -> None:
@@ -604,7 +609,7 @@ async def agg_scenes_by_speaker(show_key: str, season: str = None, episode_key: 
     return s
 
 
-async def agg_scene_events_by_speaker(show_key: str, season: str = None, episode_key: str = None, dialog: str = None) -> Search:
+def agg_scene_events_by_speaker(show_key: str, season: str = None, episode_key: str = None, dialog: str = None) -> Search:
     print(f'begin agg_scene_events_by_speaker for show_key={show_key} season={season} episode_key={episode_key} dialog={dialog}')
 
     s = Search(index='transcripts')

--- a/app/es/es_response_transformer.py
+++ b/app/es/es_response_transformer.py
@@ -444,7 +444,7 @@ def return_all_episode_relations(s: Search) -> dict:
     return results
 
 
-async def return_episode_count(s: Search) -> int:
+def return_episode_count(s: Search) -> int:
     print(f'begin return_episode_count for s.to_dict()={s.to_dict()}')
 
     s = s.execute()
@@ -479,7 +479,7 @@ async def return_episodes_by_speaker(s: Search, agg_episode_count: str, location
     return results
 
 
-async def return_episodes_by_location(s: Search, agg_episode_count: str) -> list:
+def return_episodes_by_location(s: Search, agg_episode_count: str) -> list:
     print(f'begin return_episodes_by_speaker s.to_dict()={s.to_dict()}')
 
     s = s.execute()
@@ -507,7 +507,7 @@ async def return_scene_count(s: Search) -> int:
     return int(s.aggregations.scene_count.value)
 
 
-async def return_scenes_by_location(s: Search, speaker: str = None) -> list:
+def return_scenes_by_location(s: Search, speaker: str = None) -> list:
     print(f'begin return_scenes_by_location for speaker={speaker} s.to_dict()={s.to_dict()}')
 
     s = s.execute()

--- a/app/es/es_response_transformer.py
+++ b/app/es/es_response_transformer.py
@@ -90,7 +90,7 @@ async def return_scenes(s: Search) -> tuple[list, int]:
     return results, scene_count
 
 
-async def return_scene_events(s: Search, location: str = None) -> tuple[list, int, int]:
+def return_scene_events(s: Search, location: str = None) -> tuple[list, int, int]:
     print(f'begin return_scene_events for location={location} s.to_dict()={s.to_dict()}')
 
     s = s.execute()

--- a/app/es/es_response_transformer.py
+++ b/app/es/es_response_transformer.py
@@ -554,7 +554,7 @@ async def return_scenes_by_speaker(s: Search, agg_scene_count: str, location: st
     return results
 
 
-async def return_scene_events_by_speaker(s: Search, dialog: str = None) -> list:
+def return_scene_events_by_speaker(s: Search, dialog: str = None) -> list:
     print(f'begin return_scene_events_by_speaker for dialog={dialog} s.to_dict()={s.to_dict()}')
 
     s = s.execute()

--- a/app/es/es_response_transformer.py
+++ b/app/es/es_response_transformer.py
@@ -43,7 +43,7 @@ async def return_episodes_by_title(s: Search) -> list:
     return results
 
 
-async def return_scenes(s: Search) -> (list, int):
+async def return_scenes(s: Search) -> tuple[list, int]:
     print(f'begin return_scenes for s.to_dict()={s.to_dict()}')
 
     s = s.execute()
@@ -90,7 +90,7 @@ async def return_scenes(s: Search) -> (list, int):
     return results, scene_count
 
 
-async def return_scene_events(s: Search, location: str = None) -> (list, int, int):
+async def return_scene_events(s: Search, location: str = None) -> tuple[list, int, int]:
     print(f'begin return_scene_events for location={location} s.to_dict()={s.to_dict()}')
 
     s = s.execute()
@@ -177,7 +177,7 @@ async def return_scene_events(s: Search, location: str = None) -> (list, int, in
     return results, scene_count, scene_event_count
 
 
-async def return_scene_events_multi_speaker(s: Search, speakers: str, location: str = None) -> (list, int, int):
+async def return_scene_events_multi_speaker(s: Search, speakers: str, location: str = None) -> tuple[list, int, int]:
     print(f'begin return_scene_events_multi_speaker for speakers={speakers} location={location} s.to_dict()={s.to_dict()}')
 
     s = s.execute()
@@ -310,7 +310,7 @@ async def return_season_count(s: Search) -> int:
     return len(s.aggregations.by_season.buckets)
 
 
-async def return_episodes(s: Search) -> (list, int, int):
+async def return_episodes(s: Search) -> tuple[list, int, int]:
     print(f'begin return_episodes for s.to_dict()={s.to_dict()}')
 
     s = s.execute()
@@ -499,7 +499,7 @@ def return_episodes_by_location(s: Search, agg_episode_count: str) -> list:
     return results
 
 
-async def return_scene_count(s: Search) -> int:
+def return_scene_count(s: Search) -> int:
     print(f'begin return_scene_count for s.to_dict()={s.to_dict()}')
 
     s = s.execute()
@@ -527,7 +527,7 @@ def return_scenes_by_location(s: Search, speaker: str = None) -> list:
     return results
 
 
-async def return_scenes_by_speaker(s: Search, agg_scene_count: str, location: str = None, other_speaker: str = None) -> list:
+def return_scenes_by_speaker(s: Search, agg_scene_count: str, location: str = None, other_speaker: str = None) -> list:
     print(f'begin return_scenes_by_speaker for location={location} other_speaker={other_speaker} s.to_dict()={s.to_dict()}')
 
     s = s.execute()
@@ -574,7 +574,7 @@ def return_scene_events_by_speaker(s: Search, dialog: str = None) -> list:
     return results
 
 
-async def return_dialog_word_counts(s: Search, speaker: str = None) -> list:
+def return_dialog_word_counts(s: Search, speaker: str = None) -> list:
     print(f'begin return_dialog_word_counts s.to_dict()={s.to_dict()}')
 
     s = s.execute()

--- a/app/es/es_write_router.py
+++ b/app/es/es_write_router.py
@@ -15,12 +15,13 @@ esw_app = APIRouter()
 
 
 @esw_app.get("/esw/init_es", tags=['ES Writer'])
-async def init_es():
+def init_es():
     '''
     Run this to explicitly define the mapping anytime the `transcripts` index is blown away and re-created. Not doing so will result in the wrong
     data types being auto-assigned to several fields in the schema mapping, and will break query (read) functionality down the line.
     '''
-    await esqb.init_transcripts_index()
+    esqb.init_transcripts_index()
+    esqb.init_character_index()
     return {"success": "success"}
 
 

--- a/app/show_metadata.py
+++ b/app/show_metadata.py
@@ -47,7 +47,8 @@ show_metadata = {
         # 'transcript_types': {
         #     'Default': 'Default'
         # }
-        'regular_cast': ['PICARD', 'RIKER', 'DATA', 'LAFORGE', 'CRUSHER', 'WORF', 'TROI', 'TASHA', 'WESLEY', 'GUINAN']
+        'regular_cast': ['PICARD', 'RIKER', 'WORF', 'DATA', 'LAFORGE', 'TROI', 'CRUSHER', 'COMPUTER', 'WESLEY', "O'BRIEN", 'GUINAN', 'TASHA', 'PULASKI', 
+                         'OGAWA', 'Q', 'ALEXANDER', 'RO', 'KEIKO', 'LWAXANA', 'BARCLAY', 'LORE', 'GOWRON', 'RAGER', 'FELTON', 'GATES']
     }
 }
 

--- a/app/show_metadata.py
+++ b/app/show_metadata.py
@@ -47,8 +47,8 @@ show_metadata = {
         # 'transcript_types': {
         #     'Default': 'Default'
         # }
-        'regular_cast': ['PICARD', 'RIKER', 'WORF', 'DATA', 'LAFORGE', 'TROI', 'CRUSHER', 'COMPUTER', 'WESLEY', "O'BRIEN", 'GUINAN', 'TASHA', 'PULASKI', 
-                         'OGAWA', 'Q', 'ALEXANDER', 'RO', 'KEIKO', 'LWAXANA', 'BARCLAY', 'LORE', 'GOWRON', 'RAGER', 'FELTON', 'GATES']
+        'regular_cast': ['PICARD', 'RIKER', 'WORF', 'DATA', 'LAFORGE', 'TROI', 'CRUSHER', 'COMPUTER', 'WESLEY', "O'BRIEN", 'GUINAN', 'TASHA', 'PULASKI'],
+        'recurring_cast': ['OGAWA', 'Q', 'ALEXANDER', 'RO', 'KEIKO', 'LWAXANA', 'BARCLAY', 'LORE', 'GOWRON', 'RAGER', 'FELTON', 'GATES']
     }
 }
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -30,7 +30,10 @@
                         <a class="nav-link {% if tdata['header'] == 'show' %}active{% endif %}" href="/web/show/{{ tdata['show_key'] }}">{{ tdata['show_key'] }}</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link {% if tdata['header'] == 'episode' %}active{% endif %}" href="/web/episode_search/{{ tdata['show_key'] }}">Episodes</a>
+                        <a class="nav-link {% if tdata['header'] == 'search' %}active{% endif %}" href="/web/episode_search/{{ tdata['show_key'] }}">Search</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link {% if tdata['header'] == 'episode' %}active{% endif %}">Episodes</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link {% if tdata['header'] == 'character' %}active{% endif %}" href="/web/character_listing/{{ tdata['show_key'] }}">Characters</a>

--- a/app/templates/episode.html
+++ b/app/templates/episode.html
@@ -8,7 +8,7 @@
 	<div class="margin">
 		<h3>Season {{ tdata['episode']['season'] }}, Episode {{ tdata['episode']['sequence_in_season'] }}: 
 			<strong>"{{ tdata['episode']['title'] }}"</strong> <small>({{ tdata['episode']['air_date']|truncate(10,true,'') }})</small>
-			<small>[<a href="/tsp_dash/show-gantt-chart?show_key={{ tdata['show_key'] }}&episode_key={{ tdata['episode_key'] }}">Dialog gantt chart</a>]</small>
+			<small>[<a href="/tsp_dash/episode-gantt-chart?show_key={{ tdata['show_key'] }}&episode_key={{ tdata['episode_key'] }}">Dialog & location gantt charts</a>]</small>
 		</h3>
 		<p>&lt;&lt;&nbsp; Previous episode &nbsp;|&nbsp; Next episode &nbsp;&gt;&gt;</p>
 		<p>&nbsp;</p>

--- a/app/templates/show.html
+++ b/app/templates/show.html
@@ -129,11 +129,13 @@
             <div class="col-4">
                 <h3>ML & data viz playground</h3>
                 <ul>
-                    <li><a href="/tsp_dash/show-cluster-scatter">KMeans clustering</a></li>
-                    <li><a href="/tsp_dash/show-3d-network-graph">Episode relations</a></li>
                     <li><a href="/tsp_dash/show-gantt-chart?show_key={{ tdata['show_key'] }}">Character and location continuity gantt charts</a></li>
+                    <li><a href="/tsp_dash/series-search-results-gantt?show_key={{ tdata['show_key'] }}">Keyword search / matching character+episode gantt charts</a></li>
+                    <li><a href="/tsp_dash/speaker-frequency-bar-chart?show_key={{ tdata['show_key'] }}">Character appearance and dialog bar charts</a></li>
                     <li><a href="/tsp_dash/speaker-line-chart?show_key={{ tdata['show_key'] }}">Character appearance and dialog line graphs</a></li>
                     <li><a href="/tsp_dash/location-line-chart?show_key={{ tdata['show_key'] }}">Location occurrence line graphs</a></li>
+                    <li><a href="/tsp_dash/show-cluster-scatter">KMeans clustering of episodes</a></li>
+                    <li><a href="/tsp_dash/show-3d-network-graph">3d network graph of episode relations</a></li>
                     <!-- <li>Matplotlib - select # clusters: <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=2">2</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=3">3</a> 
                         <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=4">4</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=5">5</a> 
                         <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=6">6</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=7">7</a> 

--- a/app/templates/show.html
+++ b/app/templates/show.html
@@ -132,7 +132,8 @@
                     <li><a href="/tsp_dash/show-cluster-scatter">KMeans clustering</a></li>
                     <li><a href="/tsp_dash/show-3d-network-graph">Episode relations</a></li>
                     <li><a href="/tsp_dash/show-gantt-chart?show_key={{ tdata['show_key'] }}">Character and location continuity gantt charts</a></li>
-                    <li><a href="/tsp_dash/speaker-line-chart?show_key={{ tdata['show_key'] }}">Character appearance and dialog continuity gantt charts</a></li>
+                    <li><a href="/tsp_dash/speaker-line-chart?show_key={{ tdata['show_key'] }}">Character appearance and dialog line graphs</a></li>
+                    <li><a href="/tsp_dash/location-line-chart?show_key={{ tdata['show_key'] }}">Location occurrence line graphs</a></li>
                     <!-- <li>Matplotlib - select # clusters: <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=2">2</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=3">3</a> 
                         <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=4">4</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=5">5</a> 
                         <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=6">6</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=7">7</a> 

--- a/app/templates/show.html
+++ b/app/templates/show.html
@@ -127,10 +127,11 @@
 
         <div class="row">
             <div class="col-4">
-                <h3>ML playground</h3>
+                <h3>ML & data viz playground</h3>
                 <ul>
                     <li><a href="/tsp_dash/show-cluster-scatter">KMeans clustering</a></li>
                     <li><a href="/tsp_dash/show-3d-network-graph">Episode relations</a></li>
+                    <li><a href="/tsp_dash/show-gantt-chart?show_key={{ show_key }}">Character continuity gantt chart</a></li>
                     <!-- <li>Matplotlib - select # clusters: <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=2">2</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=3">3</a> 
                         <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=4">4</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=5">5</a> 
                         <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=6">6</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=7">7</a> 

--- a/app/templates/show.html
+++ b/app/templates/show.html
@@ -131,7 +131,7 @@
                 <ul>
                     <li><a href="/tsp_dash/show-cluster-scatter">KMeans clustering</a></li>
                     <li><a href="/tsp_dash/show-3d-network-graph">Episode relations</a></li>
-                    <li><a href="/tsp_dash/show-gantt-chart?show_key={{ show_key }}">Character continuity gantt chart</a></li>
+                    <li><a href="/tsp_dash/show-gantt-chart?show_key={{ show_key }}">Character and location continuity gantt charts</a></li>
                     <!-- <li>Matplotlib - select # clusters: <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=2">2</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=3">3</a> 
                         <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=4">4</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=5">5</a> 
                         <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=6">6</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=7">7</a> 

--- a/app/templates/show.html
+++ b/app/templates/show.html
@@ -131,7 +131,8 @@
                 <ul>
                     <li><a href="/tsp_dash/show-cluster-scatter">KMeans clustering</a></li>
                     <li><a href="/tsp_dash/show-3d-network-graph">Episode relations</a></li>
-                    <li><a href="/tsp_dash/show-gantt-chart?show_key={{ show_key }}">Character and location continuity gantt charts</a></li>
+                    <li><a href="/tsp_dash/show-gantt-chart?show_key={{ tdata['show_key'] }}">Character and location continuity gantt charts</a></li>
+                    <li><a href="/tsp_dash/speaker-line-chart?show_key={{ tdata['show_key'] }}">Character appearance and dialog continuity gantt charts</a></li>
                     <!-- <li>Matplotlib - select # clusters: <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=2">2</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=3">3</a> 
                         <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=4">4</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=5">5</a> 
                         <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=6">6</a> <a href="/web/graph/{{ tdata['show_key'] }}?num_clusters=7">7</a> 

--- a/app/web/fig_builder.py
+++ b/app/web/fig_builder.py
@@ -457,29 +457,42 @@ def build_location_line_chart(show_key: str, df: pd.DataFrame, span_granularity:
 
 
 def build_speaker_frequency_bar(show_key: str, df: pd.DataFrame, span_granularity: str, aggregate_ratio: bool, season: int, sequence_in_season: int = None) -> go.Figure:
+    print(f'in build_speaker_frequency_bar show_key={show_key} span_granularity={span_granularity} aggregate_ratio={aggregate_ratio} season={season} sequence_in_season={sequence_in_season}')
 
     # in this context:
     #   - `aggregate_ratio=True`: intra-season episode-by-episode tabulation using sum()
     #   - `aggregate_ratio=False`: inter-season comparison between totals using max() (and `sequence_in_season` is ignored)
     if aggregate_ratio:
-        # TODO this is a placeholder
-        sum_df = df
+        if not season:
+            season = 1
+        if not sequence_in_season:
+            sequence_in_season = 1
+        df = df.loc[df['season'] == season]
+        df = df.loc[df['sequence_in_season'] <= sequence_in_season]
+        # x = f'{span_granularity}_count'
+        # # if `span_granularity='episode'` dynamically populate `episode_count` column using `scene_count` column to enable episode tabulation
+        # if span_granularity == 'episode':
+        #     df['episode_count'] = df['scene_count'].apply(lambda x: 1 if x > 0 else 0)
+        # sum_df = df.groupby('speaker', as_index=False)[x].sum()
+        
     else:
         if season:
             df = df.loc[df['season'] == season]
-        x = f'{span_granularity}_count'
-        # if `span_granularity='episode'` dynamically populate `episode_count` column using `scene_count` column to enable episode tabulation
-        if span_granularity == 'episode':
-            df['episode_count'] = df['scene_count'].apply(lambda x: 1 if x > 0 else 0)
-        sum_df = df.groupby('speaker', as_index=False)[x].sum()
+        # x = f'{span_granularity}_count'
+        # # if `span_granularity='episode'` dynamically populate `episode_count` column using `scene_count` column to enable episode tabulation
+        # if span_granularity == 'episode':
+        #     df['episode_count'] = df['scene_count'].apply(lambda x: 1 if x > 0 else 0)
+        # sum_df = df.groupby('speaker', as_index=False)[x].sum()
 
-    # sum_df.reset_index()
-
-    # sum_df = df['speaker'].unique
+    x = f'{span_granularity}_count'
+    # if `span_granularity='episode'` dynamically populate `episode_count` column using `scene_count` column to enable episode tabulation
+    if span_granularity == 'episode':
+        df['episode_count'] = df['scene_count'].apply(lambda x: 1 if x > 0 else 0)
+    sum_df = df.groupby('speaker', as_index=False)[x].sum()
 
     sum_df.sort_values(x, ascending=False, inplace=True)
 
-    file_path = f'./app/data/test_speaker_frequency_bar_{show_key}_{season}.csv'
+    file_path = f'./app/data/test_speaker_frequency_bar_{show_key}_{season}_{sequence_in_season}.csv'
     sum_df.to_csv(file_path)
 
     # custom_data = []  # TODO

--- a/app/web/fig_builder.py
+++ b/app/web/fig_builder.py
@@ -264,16 +264,21 @@ def build_episode_gantt(show_key: str, data: list):
     return fig
 
 
-def build_show_gantt(show_key: str, data: list):
-    print(f'in build_show_gantt show_key={show_key}')
+def build_show_gantt(show_key: str, data: list, type: str):
+    print(f'in build_show_gantt show_key={show_key} type={type}')
 
-    # TODO last minute hack to reduce size, should probably be configurable and/or limited upstream
-    trimmed_data = []
-    for d in data:
-        if d['Task'] in show_metadata[show_key]['regular_cast']:
-            trimmed_data.append(d)
+    # TODO where/how should this truncation happen?
+    if type == 'speakers':
+        title='Character continuity over duration of series'
+        trimmed_data = []
+        for d in data:
+            if d['Task'] in show_metadata[show_key]['regular_cast']:
+                trimmed_data.append(d)
+        data = trimmed_data
+    elif type == 'locations':
+        title='Scene location continuity over course of series'
 
-    df = pd.DataFrame(trimmed_data)
+    df = pd.DataFrame(data)
 
     span_keys = df.Task.unique()
     keys_to_colors = {}
@@ -286,7 +291,7 @@ def build_show_gantt(show_key: str, data: list):
         keys_to_colors[sk] = rgb
         colors_to_keys[rgb] = sk
 
-    fig = ff.create_gantt(df, index_col='Task', bar_width=0.1, colors=keys_to_colors, group_tasks=True, title='Character continuity over duration of series')
+    fig = ff.create_gantt(df, index_col='Task', bar_width=0.1, colors=keys_to_colors, group_tasks=True, title=title, height=1000) # TODO scale height to number of rows
     fig.update_layout(xaxis_type='linear', autosize=False)
 
     # inject dialog into hover 'text' property

--- a/app/web/fig_builder.py
+++ b/app/web/fig_builder.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 import igraph as ig
 import io
 import matplotlib
@@ -13,7 +12,7 @@ import random
 from sklearn.manifold import TSNE
 
 import app.es.es_read_router as esr
-from app.show_metadata import ShowKey
+from app.show_metadata import ShowKey, show_metadata
 import app.web.fig_metadata as fm
 
 
@@ -213,8 +212,8 @@ def build_3d_network_graph(show_key: str, data: dict):
     return fig    
 
 
-def build_show_timeline(show_key: str, data: list):
-    print(f'in build_show_timeline show_key={show_key}')
+def build_episode_gantt(show_key: str, data: list):
+    print(f'in build_episode_gantt show_key={show_key}')
 
     '''
     reference:
@@ -236,7 +235,8 @@ def build_show_timeline(show_key: str, data: list):
         keys_to_colors[sk] = rgb
         colors_to_keys[rgb] = sk
 
-    fig = ff.create_gantt(df, index_col='Task', bar_width=0.1, colors=keys_to_colors, group_tasks=True)
+    fig = ff.create_gantt(df, index_col='Task', bar_width=0.1, colors=keys_to_colors, group_tasks=True, 
+                          title='Character dialog over duration of episode') # TODO change this for locations
     fig.update_layout(xaxis_type='linear', autosize=False)
 
     # inject dialog into hover 'text' property
@@ -258,6 +258,56 @@ def build_show_timeline(show_key: str, data: list):
                 finish_row = df.loc[(df['Task'] == gantt_row_key) & (df['Finish'] == word_i)]
                 if len(finish_row) > 0 and 'Line' in finish_row.iloc[0]:
                     gantt_row_text[i] = finish_row.iloc[0]['Line']
+
+            gantt_row.update(text=gantt_row_text, hoverinfo='all') # TODO hoverinfo='text+y' would remove word index
+    
+    return fig
+
+
+def build_show_gantt(show_key: str, data: list):
+    print(f'in build_show_gantt show_key={show_key}')
+
+    # TODO last minute hack to reduce size, should probably be configurable and/or limited upstream
+    trimmed_data = []
+    for d in data:
+        if d['Task'] in show_metadata[show_key]['regular_cast']:
+            trimmed_data.append(d)
+
+    df = pd.DataFrame(trimmed_data)
+
+    span_keys = df.Task.unique()
+    keys_to_colors = {}
+    colors_to_keys = {}
+    for sk in span_keys:
+        r = random.randrange(255)
+        g = random.randrange(255)
+        b = random.randrange(255)
+        rgb = f'rgb({r},{g},{b})'
+        keys_to_colors[sk] = rgb
+        colors_to_keys[rgb] = sk
+
+    fig = ff.create_gantt(df, index_col='Task', bar_width=0.1, colors=keys_to_colors, group_tasks=True, title='Character continuity over duration of series')
+    fig.update_layout(xaxis_type='linear', autosize=False)
+
+    # inject dialog into hover 'text' property
+    for gantt_row in fig['data']:
+        if 'text' in gantt_row and gantt_row['text'] and len(gantt_row['text']) > 0:
+            # once gantt figure is generated, speaker and location info is distributed across figure 'data' elements, and 'name' is not stored for every row.
+            # the rgb data stored in 'legendgroup' seems to be the only way to reverse lookup which speaker or location is being referenced, hence the colors_to_keys map.
+            rgb_val = gantt_row['legendgroup'].replace(' ', '')
+            gantt_row_key = colors_to_keys[rgb_val]
+            # the 'text' of a gantt row is stored in an unnamed 'data' element (associated to a gantt row via its 'legendgroup' rgb color) as a tuple, making it immutable.
+            # rather than updating it index-by-index, it must be copied, cast as a list, mutated iteratively, and updated in one swoop via gantt_row.update at the end.
+            gantt_row_text = list(gantt_row['text'])
+            for i in range(len(gantt_row['x'])):
+                episode_i = gantt_row['x'][i]
+                start_row = df.loc[(df['Task'] == gantt_row_key) & (df['Start'] == episode_i)]
+                if len(start_row) > 0 and 'Info' in start_row.iloc[0]:
+                    gantt_row_text[i] = start_row.iloc[0]['Info']
+                    continue
+                # finish_row = df.loc[(df['Info'] == gantt_row_key) & (df['Finish'] == episode_i)]
+                # if len(finish_row) > 0 and 'Info' in finish_row.iloc[0]:
+                #     gantt_row_text[i] = finish_row.iloc[0]['Info']
 
             gantt_row.update(text=gantt_row_text, hoverinfo='all') # TODO hoverinfo='text+y' would remove word index
     

--- a/app/web/fig_builder.py
+++ b/app/web/fig_builder.py
@@ -456,6 +456,47 @@ def build_location_line_chart(show_key: str, df: pd.DataFrame, span_granularity:
     return fig
 
 
+def build_speaker_frequency_bar(show_key: str, df: pd.DataFrame, span_granularity: str, aggregate_ratio: bool, season: int, sequence_in_season: int = None) -> go.Figure:
+
+    # in this context:
+    #   - `aggregate_ratio=True`: intra-season episode-by-episode tabulation using sum()
+    #   - `aggregate_ratio=False`: inter-season comparison between totals using max() (and `sequence_in_season` is ignored)
+    if aggregate_ratio:
+        # TODO this is a placeholder
+        sum_df = df
+    else:
+        if season:
+            df = df.loc[df['season'] == season]
+        x = f'{span_granularity}_count'
+        # if `span_granularity='episode'` dynamically populate `episode_count` column using `scene_count` column to enable episode tabulation
+        if span_granularity == 'episode':
+            df['episode_count'] = df['scene_count'].apply(lambda x: 1 if x > 0 else 0)
+        sum_df = df.groupby('speaker', as_index=False)[x].sum()
+
+    # sum_df.reset_index()
+
+    # sum_df = df['speaker'].unique
+
+    sum_df.sort_values(x, ascending=False, inplace=True)
+
+    file_path = f'./app/data/test_speaker_frequency_bar_{show_key}_{season}.csv'
+    sum_df.to_csv(file_path)
+
+    # custom_data = []  # TODO
+
+    fig = px.bar(sum_df, x=x, y='speaker', color='speaker' 
+                    # custom_data=custom_data, hover_name=cols.VOTE_WEIGHT, hover_data=hover_data,
+                    # text=cols.EC_VOTES, animation_frame=cols.YEAR, # ignored if df is for single year
+                    # color_discrete_map=color_discrete_map, category_orders=category_orders,
+                    # labels={cols.GROUP: groups_label},
+                    # range_x=[vw_min,vw_max], log_x=True, height=fig_height
+                    )
+
+    fig.update_layout(showlegend=False)
+    
+    return fig
+
+
 # def build_speaker_line_chart(show_key: str, data: list, aggregate_ratio: bool = False) -> go.Figure:
 #     print(f'in build_speaker_line_chart show_key={show_key}')
 

--- a/app/web/fig_builder.py
+++ b/app/web/fig_builder.py
@@ -16,6 +16,7 @@ from sklearn.manifold import TSNE
 
 import app.es.es_read_router as esr
 from app.show_metadata import ShowKey, show_metadata
+from app.web.fig_helper import apply_animation_settings
 import app.web.fig_metadata as fm
 
 
@@ -456,56 +457,77 @@ def build_location_line_chart(show_key: str, df: pd.DataFrame, span_granularity:
     return fig
 
 
-def build_speaker_frequency_bar(show_key: str, df: pd.DataFrame, span_granularity: str, aggregate_ratio: bool, season: int, sequence_in_season: int = None) -> go.Figure:
-    print(f'in build_speaker_frequency_bar show_key={show_key} span_granularity={span_granularity} aggregate_ratio={aggregate_ratio} season={season} sequence_in_season={sequence_in_season}')
+def build_speaker_frequency_bar(show_key: str, df: pd.DataFrame, span_granularity: str, aggregate_ratio: bool, season: int, 
+                                sequence_in_season: int = None, animate: bool = False) -> go.Figure:
+    print(f'in build_speaker_frequency_bar show_key={show_key} span_granularity={span_granularity} aggregate_ratio={aggregate_ratio} season={season} sequence_in_season={sequence_in_season} animate={animate}')
+
+    animation_frame = None
 
     # in this context:
     #   - `aggregate_ratio=True`: intra-season episode-by-episode tabulation using sum()
     #   - `aggregate_ratio=False`: inter-season comparison between totals using max() (and `sequence_in_season` is ignored)
     if aggregate_ratio:
-        if not season:
-            season = 1
-        if not sequence_in_season:
-            sequence_in_season = 1
-        df = df.loc[df['season'] == season]
-        df = df.loc[df['sequence_in_season'] <= sequence_in_season]
-        # x = f'{span_granularity}_count'
-        # # if `span_granularity='episode'` dynamically populate `episode_count` column using `scene_count` column to enable episode tabulation
-        # if span_granularity == 'episode':
-        #     df['episode_count'] = df['scene_count'].apply(lambda x: 1 if x > 0 else 0)
-        # sum_df = df.groupby('speaker', as_index=False)[x].sum()
-        
-    else:
-        if season:
+        if animate:
+            animation_frame = 'episode_in_season'
+        else:
+            if not season:
+                season = 1
+            if not sequence_in_season:
+                sequence_in_season = 1
             df = df.loc[df['season'] == season]
-        # x = f'{span_granularity}_count'
-        # # if `span_granularity='episode'` dynamically populate `episode_count` column using `scene_count` column to enable episode tabulation
-        # if span_granularity == 'episode':
-        #     df['episode_count'] = df['scene_count'].apply(lambda x: 1 if x > 0 else 0)
-        # sum_df = df.groupby('speaker', as_index=False)[x].sum()
+            df = df.loc[df['sequence_in_season'] <= sequence_in_season]
+            # x = f'{span_granularity}_count'
+            # # if `span_granularity='episode'` dynamically populate `episode_count` column using `scene_count` column to enable episode tabulation
+            # if span_granularity == 'episode':
+            #     df['episode_count'] = df['scene_count'].apply(lambda x: 1 if x > 0 else 0)
+            # sum_df = df.groupby('speaker', as_index=False)[x].sum()    
+    else:
+        if animate:
+            animation_frame = 'season'
+        else:
+            if season:
+                df = df.loc[df['season'] == season]
+            # x = f'{span_granularity}_count'
+            # # if `span_granularity='episode'` dynamically populate `episode_count` column using `scene_count` column to enable episode tabulation
+            # if span_granularity == 'episode':
+            #     df['episode_count'] = df['scene_count'].apply(lambda x: 1 if x > 0 else 0)
+            # sum_df = df.groupby('speaker', as_index=False)[x].sum()
 
     x = f'{span_granularity}_count'
     # if `span_granularity='episode'` dynamically populate `episode_count` column using `scene_count` column to enable episode tabulation
     if span_granularity == 'episode':
         df['episode_count'] = df['scene_count'].apply(lambda x: 1 if x > 0 else 0)
-    sum_df = df.groupby('speaker', as_index=False)[x].sum()
+    sum_df = df.groupby(['speaker', 'season'], as_index=False)[x].sum()
 
-    sum_df.sort_values(x, ascending=False, inplace=True)
+    # sum_df.sort_values(['season', x], ascending=[True, False], inplace=True)
+    # category_orders = {'speaker': sum_df['speaker'].unique()}
 
-    file_path = f'./app/data/test_speaker_frequency_bar_{show_key}_{season}_{sequence_in_season}.csv'
+    if animate:
+        file_path = f'./app/data/speaker_frequency_bar_{show_key}_{span_granularity}_animation.csv'
+    else:
+        file_path = f'./app/data/speaker_frequency_bar_{show_key}_{span_granularity}_{season}_{sequence_in_season}.csv'
     sum_df.to_csv(file_path)
 
     # custom_data = []  # TODO
 
-    fig = px.bar(sum_df, x=x, y='speaker', color='speaker' 
-                    # custom_data=custom_data, hover_name=cols.VOTE_WEIGHT, hover_data=hover_data,
-                    # text=cols.EC_VOTES, animation_frame=cols.YEAR, # ignored if df is for single year
-                    # color_discrete_map=color_discrete_map, category_orders=category_orders,
-                    # labels={cols.GROUP: groups_label},
-                    # range_x=[vw_min,vw_max], log_x=True, height=fig_height
-                    )
+    fig = px.bar(sum_df, x=x, y='speaker', color='speaker',
+                # custom_data=custom_data, hover_name=cols.VOTE_WEIGHT, hover_data=hover_data,
+                # text=cols.EC_VOTES, 
+                 animation_frame=animation_frame, # ignored if df is for single year
+                #  category_orders=category_orders,
+                # color_discrete_map=color_discrete_map, category_orders=category_orders,
+                # labels={cols.GROUP: groups_label},
+                # range_x=[vw_min,vw_max], log_x=True, height=fig_height
+    )
 
     fig.update_layout(showlegend=False)
+
+    fig.update_layout(
+        yaxis={'tickangle': 35, 'showticklabels': True, 'type': 'category', 'tickfont_size': 8},
+        yaxis_categoryorder='total ascending') # yaxis_categoryorder
+ 
+    if animate:
+        apply_animation_settings(fig, 'TODO', frame_rate=1500)
     
     return fig
 

--- a/app/web/fig_builder.py
+++ b/app/web/fig_builder.py
@@ -264,7 +264,7 @@ def build_episode_gantt(show_key: str, data: list):
     return fig
 
 
-def build_show_gantt(show_key: str, data: list, type: str):
+def build_series_gantt(show_key: str, data: list, type: str):
     print(f'in build_show_gantt show_key={show_key} type={type}')
 
     # TODO where/how should this truncation happen?
@@ -316,6 +316,39 @@ def build_show_gantt(show_key: str, data: list, type: str):
 
             gantt_row.update(text=gantt_row_text, hoverinfo='all') # TODO hoverinfo='text+y' would remove word index
     
+    return fig
+
+
+def build_speaker_line_chart(show_key: str, data: list, aggregate_ratio: bool = False):
+    print(f'in build_speaker_line_chart show_key={show_key}')
+
+    df = pd.DataFrame(data)
+
+    y='Span'
+
+    if aggregate_ratio:
+        df['Span_Ratio'] = df['Span'] / df['Denominator']
+        y='Span_Ratio'
+
+    # drop any speaker having no span data during the episode range
+    speaker_span_aggs = df.groupby('Speaker')['Span'].sum()
+    for key, value in speaker_span_aggs.to_dict().items():
+        if value == 0:
+            df = df[df['Speaker'] != key]
+
+    # span_keys = df.Task.unique()
+    # keys_to_colors = {}
+    # colors_to_keys = {}
+    # for sk in span_keys:
+    #     r = random.randrange(255)
+    #     g = random.randrange(255)
+    #     b = random.randrange(255)
+    #     rgb = f'rgb({r},{g},{b})'
+    #     keys_to_colors[sk] = rgb
+    #     colors_to_keys[rgb] = sk
+
+    fig = px.line(df, x='Episode_i', y=y, color='Speaker', height=800, render_mode='svg', line_shape='spline')
+
     return fig
 
 

--- a/app/web/fig_builder.py
+++ b/app/web/fig_builder.py
@@ -468,7 +468,10 @@ def build_speaker_frequency_bar(show_key: str, df: pd.DataFrame, span_granularit
     #   - `aggregate_ratio=False`: inter-season comparison between totals using max() (and `sequence_in_season` is ignored)
     if aggregate_ratio:
         if animate:
-            animation_frame = 'episode_in_season'
+            animation_frame = 'sequence_in_season'
+            df = df.loc[df['season'] == season]
+            x = f'{span_granularity}_count_pct_of_season'
+            sum_df = df
         else:
             if not season:
                 season = 1
@@ -476,28 +479,22 @@ def build_speaker_frequency_bar(show_key: str, df: pd.DataFrame, span_granularit
                 sequence_in_season = 1
             df = df.loc[df['season'] == season]
             df = df.loc[df['sequence_in_season'] <= sequence_in_season]
-            # x = f'{span_granularity}_count'
-            # # if `span_granularity='episode'` dynamically populate `episode_count` column using `scene_count` column to enable episode tabulation
-            # if span_granularity == 'episode':
-            #     df['episode_count'] = df['scene_count'].apply(lambda x: 1 if x > 0 else 0)
-            # sum_df = df.groupby('speaker', as_index=False)[x].sum()    
+            x = f'{span_granularity}_count'
+            # if `span_granularity='episode'` dynamically populate `episode_count` column using `scene_count` column to enable episode tabulation
+            if span_granularity == 'episode':
+                df['episode_count'] = df['scene_count'].apply(lambda x: 1 if x > 0 else 0)
+            sum_df = df.groupby(['speaker', 'season'], as_index=False)[x].sum()   
     else:
         if animate:
             animation_frame = 'season'
         else:
             if season:
                 df = df.loc[df['season'] == season]
-            # x = f'{span_granularity}_count'
-            # # if `span_granularity='episode'` dynamically populate `episode_count` column using `scene_count` column to enable episode tabulation
-            # if span_granularity == 'episode':
-            #     df['episode_count'] = df['scene_count'].apply(lambda x: 1 if x > 0 else 0)
-            # sum_df = df.groupby('speaker', as_index=False)[x].sum()
-
-    x = f'{span_granularity}_count'
-    # if `span_granularity='episode'` dynamically populate `episode_count` column using `scene_count` column to enable episode tabulation
-    if span_granularity == 'episode':
-        df['episode_count'] = df['scene_count'].apply(lambda x: 1 if x > 0 else 0)
-    sum_df = df.groupby(['speaker', 'season'], as_index=False)[x].sum()
+        x = f'{span_granularity}_count'
+        # if `span_granularity='episode'` dynamically populate `episode_count` column using `scene_count` column to enable episode tabulation
+        if span_granularity == 'episode':
+            df['episode_count'] = df['scene_count'].apply(lambda x: 1 if x > 0 else 0)
+        sum_df = df.groupby(['speaker', 'season'], as_index=False)[x].sum()
 
     # sum_df.sort_values(['season', x], ascending=[True, False], inplace=True)
     # category_orders = {'speaker': sum_df['speaker'].unique()}
@@ -506,7 +503,7 @@ def build_speaker_frequency_bar(show_key: str, df: pd.DataFrame, span_granularit
         file_path = f'./app/data/speaker_frequency_bar_{show_key}_{span_granularity}_animation.csv'
     else:
         file_path = f'./app/data/speaker_frequency_bar_{show_key}_{span_granularity}_{season}_{sequence_in_season}.csv'
-    sum_df.to_csv(file_path)
+    # sum_df.to_csv(file_path)
 
     # custom_data = []  # TODO
 

--- a/app/web/fig_builder.py
+++ b/app/web/fig_builder.py
@@ -355,6 +355,41 @@ def build_speaker_line_chart(show_key: str, df: pd.DataFrame, span_granularity: 
     return fig
 
 
+def build_location_line_chart(show_key: str, df: pd.DataFrame, span_granularity: str, aggregate_ratio: bool = False, season: str = None):
+    print(f'in build_location_line_chart show_key={show_key} span_granularity={span_granularity} aggregate_ratio={aggregate_ratio} season={season}')
+
+    y = f'{span_granularity}_count'
+    if aggregate_ratio or span_granularity == 'episode':
+        if season:
+            y = f'{y}_pct_of_season'
+        else:
+            y = f'{y}_pct_of_series'
+
+    if season:
+        df = df.loc[df['season'] == season]
+
+    # drop any location having no span data during the episode range
+    location_span_aggs = df.groupby('location')[y].sum()
+    for key, value in location_span_aggs.to_dict().items():
+        if value == 0:
+            df = df[df['location'] != key]
+
+    custom_data = ['location', 'episode_title', 'season', 'sequence_in_season']
+
+    fig = px.line(df, x='episode_i', y=y, color='location', height=800, render_mode='svg', line_shape='spline',
+                  custom_data=custom_data)
+
+    fig.update_traces(
+        hovertemplate="<br>".join([
+            "<b>%{customdata[0]}: %{y:.2f}</b>",
+            "Season %{customdata[2]}, Episode %{customdata[3]}:",
+            "\"%{customdata[1]}\"",
+        ])
+    )
+
+    return fig
+
+
 # def build_speaker_line_chart(show_key: str, data: list, aggregate_ratio: bool = False):
 #     print(f'in build_speaker_line_chart show_key={show_key}')
 

--- a/app/web/fig_helper.py
+++ b/app/web/fig_helper.py
@@ -1,0 +1,33 @@
+import plotly.graph_objects as go
+
+FRAME_RATE = 1000
+
+def apply_animation_settings(fig: go.Figure, base_fig_title: str, frame_rate: int = None) -> None:
+    """
+    generic recipe of steps to execute on animation figure after its built: explicitly set frame rate, dynamically update fig title, etc
+    """
+
+    print(f'in apply_animation_settings frame_rate={frame_rate}')
+    if not frame_rate:
+        frame_rate = FRAME_RATE
+
+    fig.layout.updatemenus[0].buttons[0].args[1]['frame']['duration'] = frame_rate
+        
+    for button in fig.layout.updatemenus[0].buttons:
+        button["args"][1]["frame"]["redraw"] = True
+    
+    # first_step = True
+    for step in fig.layout.sliders[0].steps:
+        step["args"][1]["frame"]["redraw"] = True
+        # if first_step:
+        #     # step["args"][1]["frame"]["duration"] = 0
+        #     first_step = False
+        # step["args"][1]["frame"]["duration"] = frame_rate
+
+    # for k in range(len(fig.frames)):
+    #     year = YEAR_0 + (k*4)
+    #     era = get_era_for_year(year)
+    #     fig.frames[k]['layout'].update(title_text=f'{base_fig_title}: {year} ({era})')
+        
+    print(f'fig.layout={fig.layout}')
+        

--- a/app/web/web_router.py
+++ b/app/web/web_router.py
@@ -130,7 +130,7 @@ async def episode_page(request: Request, show_key: ShowKey, episode_key: str, se
 		if location and not (dialog or speaker):
 			matches = await esr.search_scenes(show_key, episode_key=episode_key, location=location)
 		else:
-			matches = await esr.search_scene_events(show_key, episode_key=episode_key, speaker=speaker, dialog=dialog, location=location)
+			matches = esr.search_scene_events(show_key, episode_key=episode_key, speaker=speaker, dialog=dialog, location=location)
 			tdata['scene_event_match_count'] = matches['scene_event_count']
 		if matches['matches']:
 			tdata['episode_match'] = matches['matches'][0]
@@ -159,7 +159,7 @@ async def episode_search_page(request: Request, show_key: ShowKey, search_type: 
 							  model_version: str = None, speakers: str = None, locationAMS: str = None):
 	tdata = {}
 
-	tdata['header'] = 'episode'
+	tdata['header'] = 'search'
 	tdata['show_key'] = show_key.value
 	if not search_type:
 		tdata['search_type'] = ''
@@ -202,7 +202,7 @@ async def episode_search_page(request: Request, show_key: ShowKey, search_type: 
 		if location and not (dialog or speaker):
 			matches = await esr.search_scenes(show_key, season=season, location=location)
 		else:
-			matches = await esr.search_scene_events(show_key, season=season, speaker=speaker, dialog=dialog, location=location)
+			matches = esr.search_scene_events(show_key, season=season, speaker=speaker, dialog=dialog, location=location)
 			tdata['scene_event_match_count'] = matches['scene_event_count']
 		tdata['episode_matches'] = matches['matches']
 		tdata['episode_match_count'] = matches['episode_count']
@@ -253,7 +253,7 @@ async def character_page(request: Request, show_key: ShowKey, speaker: str, sear
 	tdata['show_key'] = show_key.value
 	tdata['speaker'] = speaker
 
-	episode_matches = await esr.search_scene_events(show_key, speaker=speaker)
+	episode_matches = esr.search_scene_events(show_key, speaker=speaker)
 	tdata['episodes'] = episode_matches['matches']
 	tdata['episode_count'] = episode_matches['episode_count']
 	tdata['scene_count'] = episode_matches['scene_count']
@@ -304,7 +304,7 @@ async def character_page(request: Request, show_key: ShowKey, speaker: str, sear
 			tdata['dialog'] = dialog
 		if location:
 			tdata['location'] = location
-		matches = await esr.search_scene_events(show_key, speaker=speaker, dialog=dialog, location=location)
+		matches = esr.search_scene_events(show_key, speaker=speaker, dialog=dialog, location=location)
 		tdata['episode_matches'] = matches['matches']
 		tdata['episode_match_count'] = matches['episode_count']
 		tdata['scene_match_count'] = matches['scene_count']

--- a/app/web/web_router.py
+++ b/app/web/web_router.py
@@ -47,7 +47,7 @@ async def show_page(request: Request, show_key: ShowKey):
 		season_locations = await esr.agg_scenes_by_location(show_key, season=season)
 		stats['location_count'] = season_locations['location_count']
 		stats['location_counts'] = utils.truncate_dict(season_locations['scenes_by_location'], season_episode_count, 1)
-		season_speakers = await esr.agg_scene_events_by_speaker(show_key, season=season)
+		season_speakers = esr.agg_scene_events_by_speaker(show_key, season=season)
 		stats['line_count'] = season_speakers['scene_events_by_speaker']['_ALL_']
 		stats['speaker_line_counts'] = utils.truncate_dict(season_speakers['scene_events_by_speaker'], season_episode_count, 1)
 		season_speaker_scene_counts = await esr.agg_scenes_by_speaker(show_key, season=season)

--- a/app/web/web_router.py
+++ b/app/web/web_router.py
@@ -54,7 +54,7 @@ async def show_page(request: Request, show_key: ShowKey):
 		stats['scene_count'] = season_speaker_scene_counts['scenes_by_speaker']['_ALL_']
 		season_speaker_episode_counts = await esr.agg_episodes_by_speaker(show_key, season=season)
 		stats['speaker_count'] = season_speaker_episode_counts['speaker_count']	
-		season_speaker_word_counts = await esr.agg_dialog_word_counts(show_key, season=season)
+		season_speaker_word_counts = esr.agg_dialog_word_counts(show_key, season=season)
 		stats['word_count'] = int(season_speaker_word_counts['dialog_word_counts']['_ALL_'])
 		# generate air_date_range
 		first_episode_in_season = tdata['episodes_by_season'][season][0]
@@ -81,7 +81,7 @@ async def episode_page(request: Request, show_key: ShowKey, episode_key: str, se
 	locations_by_scene = esr.agg_scenes_by_location(show_key, episode_key=episode_key)
 	tdata['locations_by_scene'] = locations_by_scene['scenes_by_location']
 
-	episode_word_counts = await esr.agg_dialog_word_counts(show_key, episode_key=episode_key)
+	episode_word_counts = esr.agg_dialog_word_counts(show_key, episode_key=episode_key)
 	tdata['episode_word_counts'] = episode_word_counts['dialog_word_counts']
 
 	speaker_counts = await esr.composite_speaker_aggs(show_key, episode_key=episode_key)
@@ -259,7 +259,7 @@ async def character_page(request: Request, show_key: ShowKey, speaker: str, sear
 	tdata['scene_count'] = episode_matches['scene_count']
 	tdata['scene_event_count'] = episode_matches['scene_event_count']
 
-	word_count = await esr.agg_dialog_word_counts(show_key, speaker=speaker)
+	word_count = esr.agg_dialog_word_counts(show_key, speaker=speaker)
 	tdata['word_count'] = int(word_count['dialog_word_counts'][speaker])
 	
 	locations_counts = esr.agg_scenes_by_location(show_key, speaker=speaker)

--- a/app/web/web_router.py
+++ b/app/web/web_router.py
@@ -44,7 +44,7 @@ async def show_page(request: Request, show_key: ShowKey):
 	for season in tdata['episodes_by_season'].keys():
 		season_episode_count = len(tdata['episodes_by_season'][season])
 		stats = {}
-		season_locations = await esr.agg_scenes_by_location(show_key, season=season)
+		season_locations = esr.agg_scenes_by_location(show_key, season=season)
 		stats['location_count'] = season_locations['location_count']
 		stats['location_counts'] = utils.truncate_dict(season_locations['scenes_by_location'], season_episode_count, 1)
 		season_speakers = esr.agg_scene_events_by_speaker(show_key, season=season)
@@ -78,7 +78,7 @@ async def episode_page(request: Request, show_key: ShowKey, episode_key: str, se
 	episode = esr.fetch_episode(show_key, episode_key)
 	tdata['episode'] = episode['es_episode']
 	
-	locations_by_scene = await esr.agg_scenes_by_location(show_key, episode_key=episode_key)
+	locations_by_scene = esr.agg_scenes_by_location(show_key, episode_key=episode_key)
 	tdata['locations_by_scene'] = locations_by_scene['scenes_by_location']
 
 	episode_word_counts = await esr.agg_dialog_word_counts(show_key, episode_key=episode_key)
@@ -211,12 +211,13 @@ async def episode_search_page(request: Request, show_key: ShowKey, search_type: 
 	elif search_type == 'semantic':
 		tdata['qtSemantic'] = qtSemantic
 		if not model_vendor:
-			model_vendor = 'webvectors'
+			model_vendor = 'openai'
 		if not model_version:
-			model_version = '29'
+			model_version = 'ada002'
 		tdata['model_vendor'] = model_vendor
 		tdata['model_version'] = model_version
 		matches = esr.vector_search(show_key, qt=qtSemantic, model_vendor=model_vendor, model_version=model_version)
+		print(f'############ matches={matches}')
 		tdata['episode_matches'] = matches['matches']
 		tdata['episode_match_count'] = len(matches['matches'])
 		tdata['tokens_processed_count'] = matches['tokens_processed_count']
@@ -261,7 +262,7 @@ async def character_page(request: Request, show_key: ShowKey, speaker: str, sear
 	word_count = await esr.agg_dialog_word_counts(show_key, speaker=speaker)
 	tdata['word_count'] = int(word_count['dialog_word_counts'][speaker])
 	
-	locations_counts = await esr.agg_scenes_by_location(show_key, speaker=speaker)
+	locations_counts = esr.agg_scenes_by_location(show_key, speaker=speaker)
 	tdata['location_counts'] = locations_counts['scenes_by_location']
 
 	co_occ_speakers_by_episode = await esr.agg_episodes_by_speaker(show_key, other_speaker=speaker)

--- a/app/web/web_router.py
+++ b/app/web/web_router.py
@@ -37,7 +37,7 @@ async def show_page(request: Request, show_key: ShowKey):
 	keywords = await esr.keywords_by_corpus(show_key, exclude_speakers=True)
 	tdata['keywords'] = keywords['keywords']
 
-	episodes_by_season = esr.list_episodes_by_season(show_key)
+	episodes_by_season = esr.list_simple_episodes_by_season(show_key)
 	tdata['episodes_by_season'] = episodes_by_season['episodes_by_season']
 
 	stats_by_season = {}
@@ -50,7 +50,7 @@ async def show_page(request: Request, show_key: ShowKey):
 		season_speakers = esr.agg_scene_events_by_speaker(show_key, season=season)
 		stats['line_count'] = season_speakers['scene_events_by_speaker']['_ALL_']
 		stats['speaker_line_counts'] = utils.truncate_dict(season_speakers['scene_events_by_speaker'], season_episode_count, 1)
-		season_speaker_scene_counts = await esr.agg_scenes_by_speaker(show_key, season=season)
+		season_speaker_scene_counts = esr.agg_scenes_by_speaker(show_key, season=season)
 		stats['scene_count'] = season_speaker_scene_counts['scenes_by_speaker']['_ALL_']
 		season_speaker_episode_counts = await esr.agg_episodes_by_speaker(show_key, season=season)
 		stats['speaker_count'] = season_speaker_episode_counts['speaker_count']	
@@ -266,7 +266,7 @@ async def character_page(request: Request, show_key: ShowKey, speaker: str, sear
 	tdata['location_counts'] = locations_counts['scenes_by_location']
 
 	co_occ_speakers_by_episode = await esr.agg_episodes_by_speaker(show_key, other_speaker=speaker)
-	co_occ_speakers_by_scene = await esr.agg_scenes_by_speaker(show_key, other_speaker=speaker)
+	co_occ_speakers_by_scene = esr.agg_scenes_by_speaker(show_key, other_speaker=speaker)
 	# TODO refactor this to generically handle dicts threading together
 	other_speakers = {}
 	for other_speaker, episode_count in co_occ_speakers_by_episode['episodes_by_speaker'].items():

--- a/publish_animation.py
+++ b/publish_animation.py
@@ -9,10 +9,12 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--show_key", "-s", help="Show key", required=True)
     parser.add_argument("--fig_type", "-f", help="Figure type", required=True)
+    parser.add_argument("--season", "-e", help="Season", required=False)
     parser.add_argument("--span_granularity", "-g", help="Span granularity", required=False)
     args = parser.parse_args()
     show_key = args.show_key
     fig_type = args.fig_type
+    season = args.season
     span_granularity = args.span_granularity
 
     valid_fig_types_to_df_sources = {'speaker_frequency_bar': 'speaker_episode_aggs'}
@@ -36,11 +38,18 @@ def main():
             raise Exception(f'Failed to publish animation: `span_granularity` is required for fig_type={fig_type}')
         if span_granularity not in valid_span_granularities:
             raise Exception(f'Failed to publish animation: span_granularity={span_granularity} must be in {valid_span_granularities}')
+        
+        if season:
+            fig = fb.build_speaker_frequency_bar(show_key, df, span_granularity, True, int(season), animate=True)
+            output_path = f'app/animations/{fig_type}_{show_key}_S{season}_{span_granularity}.html'
+            fig.write_html(output_path, auto_play=False)
+            print(f'Successfully generated and saved animation html file to output_path={output_path}')
 
-        fig = fb.build_speaker_frequency_bar(show_key, df, span_granularity, False, None, animate=True)
-        output_path = f'app/animations/{fig_type}_{show_key}_{span_granularity}.html'
-        fig.write_html(output_path, auto_play=False)
-        print(f'Successfully generated and saved animation html file to output_path={output_path}')
+        else:
+            fig = fb.build_speaker_frequency_bar(show_key, df, span_granularity, False, None, animate=True)
+            output_path = f'app/animations/{fig_type}_{show_key}_{span_granularity}.html'
+            fig.write_html(output_path, auto_play=False)
+            print(f'Successfully generated and saved animation html file to output_path={output_path}')
 
 
 if __name__ == '__main__':

--- a/publish_animation.py
+++ b/publish_animation.py
@@ -1,0 +1,47 @@
+import argparse
+import os
+import pandas as pd
+
+import app.web.fig_builder as fb
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--show_key", "-s", help="Show key", required=True)
+    parser.add_argument("--fig_type", "-f", help="Figure type", required=True)
+    parser.add_argument("--span_granularity", "-g", help="Span granularity", required=False)
+    args = parser.parse_args()
+    show_key = args.show_key
+    fig_type = args.fig_type
+    span_granularity = args.span_granularity
+
+    valid_fig_types_to_df_sources = {'speaker_frequency_bar': 'speaker_episode_aggs'}
+    valid_span_granularities = ['word', 'line', 'scene', 'episode']
+
+    if fig_type not in valid_fig_types_to_df_sources:
+        raise Exception(f'Failed to publish animation: fig_type={fig_type} must be in {valid_fig_types_to_df_sources.keys()}')
+
+    # fetch or generate aggregate speaker data and build speaker frequency bar chart
+    df_source = valid_fig_types_to_df_sources[fig_type]
+    file_path = f'./app/data/{df_source}_{show_key}.csv'
+    if os.path.isfile(file_path):
+        df = pd.read_csv(file_path)
+        print(f'Loading dataframe for fig_type={fig_type} df_source={df_source} using file_path={file_path}')
+    else:
+        raise Exception(f'Failed to publish animation: unable to fetch dataframe for fig_type={fig_type} df_source={df_source} using file_path={file_path}')
+
+    # generate and store animation html for fig_type
+    if fig_type == 'speaker_frequency_bar':
+        if not span_granularity:
+            raise Exception(f'Failed to publish animation: `span_granularity` is required for fig_type={fig_type}')
+        if span_granularity not in valid_span_granularities:
+            raise Exception(f'Failed to publish animation: span_granularity={span_granularity} must be in {valid_span_granularities}')
+
+        fig = fb.build_speaker_frequency_bar(show_key, df, span_granularity, False, None, animate=True)
+        output_path = f'app/animations/{fig_type}_{show_key}_{span_granularity}.html'
+        fig.write_html(output_path, auto_play=False)
+        print(f'Successfully generated and saved animation html file to output_path={output_path}')
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ pytest-asyncio==0.23.3
 python-multipart==0.0.6
 requests==2.30.0
 scikit-learn==1.4.0
+scipy==1.10.1
 # starlette==0.27.0
 tortoise-orm==0.20.0
 uvicorn==0.23.2 


### PR DESCRIPTION
* /esr/generate_episode_gantt_sequence endpoint for building episode-level time-series data of speaker dialog (words/lines/scene appearances) and scene locations
* plotly gantt chart data visualizations of episode-level speaker dialog and location sequences (currently with runtime dependency on /esr/generate_episode_gantt_sequence, no data persisted)
* /esr/generate_series_gantt_sequence endpoint for building series-level time-series data of aggregate speaker word/line/scene/episode counts and frequency
* plotly gantt chart data visualizations of series-level speaker dialog/appearance continuity (currently with runtime dependency on /esr/generate_series_gantt_sequence, no data persisted)
* /esr/generate_speaker_line_chart_sequences and /esr/generate_location_line_chart_sequences endpoints: generates and persists series-wide episode-by-episode word/line/scene/episode/location counts and percentages of each toward overall season- and season-level tallies in pandas dataframes
* plotly line charts of speaker and location series-, season-, and episode-level word/line/scene/episode/location appearances in absolute terms and as aggregate ratio
* overlay keyword search result output from /esr/search_scene_event into series-level speaker continuity data from new /esr/generate_series_gantt_sequence endpoint in modified heat-map style search result gantt chart
* incorporate stored dataframe output of new /esr/generate_speaker_line_chart_sequences endpoint into plotly bar plot builders displaying speakers sorted by word/line/scene/episode appearances and frequency, at series-, season-, and episode-level
* set up plotly animation publisher script for generating speaker word/line/scene/episode frequency time-series bar plots
* define character es index (and proceed to leave it sitting there unpopulated)
* remove async function definitions as needed to avoid plotly conflicts 